### PR TITLE
Add update counts to vertices and edges

### DIFF
--- a/data-generation/src/main/scala/GeneratedGraph.scala
+++ b/data-generation/src/main/scala/GeneratedGraph.scala
@@ -11,8 +11,8 @@ object GeneratedGraph {
   def genGridGraph[A,B](sc: SparkContext): Graph[(Int, Int), Double] =
     GraphGenerators.gridGraph(sc, 5 , 5)
 
-  def genLogNormalGraph(sc: SparkContext): Graph[String, String] =
-    GraphGenerators.logNormalGraph(sc, 5, 5)
+  def genLogNormalGraph(sc: SparkContext, nvert:Int=5, nedge:Int=5): Graph[String, String] =
+    GraphGenerators.logNormalGraph(sc, nvert, nedge)
       .mapVertices((id, num) => getRandomName)
       .mapEdges(edge => getRandomRelation)
 

--- a/data-generation/src/main/scala/Main.scala
+++ b/data-generation/src/main/scala/Main.scala
@@ -1,14 +1,6 @@
-import TopologyGraphGenerator.generateGraph
-import UpdateDistributions.addLogNormalGraphUpdateDistribution
 import org.apache.spark.sql.SparkSession
 
 
 object Main extends App {
   val spark = SparkSession.builder.master("local").getOrCreate
-  val graph = generateGraph(spark, 1, filePath = "src/main/resources/reptilia-tortoise-network-sl.csv", delimiter = " ")
-  spark.sparkContext.setLogLevel("WARN")
-  //val anothergraph = genLogNormalGraph(spark.sparkContext, 1000, 100)
-  val withDistribution = addLogNormalGraphUpdateDistribution(spark.sparkContext, graph, 5, 0.5)
-  withDistribution.vertices.foreach(x => println(x._1, x._2))
-  withDistribution.edges.foreach(x => println(x.srcId, x.dstId, x.attr))
 }

--- a/data-generation/src/main/scala/Main.scala
+++ b/data-generation/src/main/scala/Main.scala
@@ -1,13 +1,14 @@
-import GeneratedGraph.genLogNormalGraph
-import UpdateDistributions.addLogNormalVertexUpdateDistribution
+import TopologyGraphGenerator.generateGraph
+import UpdateDistributions.addVertexUpdateDistribution
 import org.apache.spark.sql.SparkSession
 
 
 object Main extends App {
   val spark = SparkSession.builder.master("local").getOrCreate
-  //val graph = generateGraph(spark, 250)
+  val graph = generateGraph(spark, 1, filePath = "src/main/resources/reptilia-tortoise-network-sl.csv", delimiter = " ")
   spark.sparkContext.setLogLevel("WARN")
-  val anothergraph = genLogNormalGraph(spark.sparkContext, 1000, 100)
-  addLogNormalVertexUpdateDistribution(anothergraph, mu = 5, sigma = 0.5)
+  //val anothergraph = genLogNormalGraph(spark.sparkContext, 1000, 100)
+  val withDistribution = addVertexUpdateDistribution(spark.sparkContext, graph, UpdateDistributionMode.Uniform, DistributionType.LogNormal, 5, 0.5)
+  withDistribution.vertices.foreach(x => println(x._1, x._2))
 
 }

--- a/data-generation/src/main/scala/Main.scala
+++ b/data-generation/src/main/scala/Main.scala
@@ -1,5 +1,5 @@
 import TopologyGraphGenerator.generateGraph
-import UpdateDistributions.addVertexUpdateDistribution
+import UpdateDistributions.addLogNormalGraphUpdateDistribution
 import org.apache.spark.sql.SparkSession
 
 
@@ -8,7 +8,7 @@ object Main extends App {
   val graph = generateGraph(spark, 1, filePath = "src/main/resources/reptilia-tortoise-network-sl.csv", delimiter = " ")
   spark.sparkContext.setLogLevel("WARN")
   //val anothergraph = genLogNormalGraph(spark.sparkContext, 1000, 100)
-  val withDistribution = addVertexUpdateDistribution(spark.sparkContext, graph, UpdateDistributionMode.Uniform, DistributionType.LogNormal, 5, 0.5)
+  val withDistribution = addLogNormalGraphUpdateDistribution(spark.sparkContext, graph, 5, 0.5)
   withDistribution.vertices.foreach(x => println(x._1, x._2))
-
+  withDistribution.edges.foreach(x => println(x.srcId, x.dstId, x.attr))
 }

--- a/data-generation/src/main/scala/Main.scala
+++ b/data-generation/src/main/scala/Main.scala
@@ -1,5 +1,5 @@
 import GeneratedGraph.genLogNormalGraph
-import UpdateDistributions.add_log_normal_update_distr_vertex
+import UpdateDistributions.addLogNormalVertexUpdateDistribution
 import org.apache.spark.sql.SparkSession
 
 
@@ -8,6 +8,6 @@ object Main extends App {
   //val graph = generateGraph(spark, 250)
   spark.sparkContext.setLogLevel("WARN")
   val anothergraph = genLogNormalGraph(spark.sparkContext, 1000, 100)
-  add_log_normal_update_distr_vertex(anothergraph, mu = 5, sigma = 0.5)
+  addLogNormalVertexUpdateDistribution(anothergraph, mu = 5, sigma = 0.5)
 
 }

--- a/data-generation/src/main/scala/Main.scala
+++ b/data-generation/src/main/scala/Main.scala
@@ -1,9 +1,13 @@
-import TopologyGraphGenerator.generateGraph
+import GeneratedGraph.genLogNormalGraph
+import UpdateDistributions.add_log_normal_update_distr_vertex
 import org.apache.spark.sql.SparkSession
 
 
 object Main extends App {
   val spark = SparkSession.builder.master("local").getOrCreate
-  val graph = generateGraph(spark, 250)
+  //val graph = generateGraph(spark, 250)
+  spark.sparkContext.setLogLevel("WARN")
+  val anothergraph = genLogNormalGraph(spark.sparkContext, 1000, 100)
+  add_log_normal_update_distr_vertex(anothergraph, mu = 5, sigma = 0.5)
 
 }

--- a/data-generation/src/main/scala/TopologyGraphGenerator.scala
+++ b/data-generation/src/main/scala/TopologyGraphGenerator.scala
@@ -1,4 +1,4 @@
-import org.apache.spark.graphx.{Edge, Graph, VertexId}
+import org.apache.spark.graphx.{Edge, Graph}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.expressions.Window
 import org.apache.spark.sql.functions.{col, lag, last, when}
@@ -9,10 +9,11 @@ object TopologyGraphGenerator {
   def generateGraph(
                      spark: SparkSession,
                      threshold: BigDecimal,
-                     filePath: String="src/main/resources/fb-messages.csv"
+                     filePath: String="src/main/resources/fb-messages.csv",
+                     delimiter: String=","
                    ):Graph[Long, (BigDecimal, BigDecimal)] = {
     val window = Window.orderBy("from", "to", "time")
-    val df = spark.read.csv(filePath)
+    val df = spark.read.option("delimiter", delimiter).csv(filePath)
       .toDF("from", "to", "time")
       .withColumn("previous", when(col("to") === lag("to", 1).over(window), lag("time", 1).over(window)).otherwise(""))
       .withColumn("closeness", when(col("previous") === "", "").otherwise(col("time") - col("previous")))
@@ -20,13 +21,12 @@ object TopologyGraphGenerator {
       .withColumn("edgeId", last(col("id"), ignoreNulls = true).over(window.rowsBetween(Window.unboundedPreceding, 0)))
     val tempDf = df.groupBy("edgeId").agg(functions.min("time").alias("from time"), functions.max("time").alias("to time"))
     val leadDf = df.as("self1").join(tempDf.as("self2"), col("self1.id") === col("self2.edgeId"), "inner").select("from", "to", "from time", "to time")
-
-    val vertices: RDD[(VertexId, Long)] = leadDf
+    leadDf.show()
+    val vertices: RDD[(Long, Long)] = leadDf
       .select("from")
       .distinct
       .rdd.map(row => row.getAs[String]("from").toLong)
-      .zipWithIndex // associate a long index to each vertex
-      .map(_.swap)
+      .map(long => (long, long))
 
     val edges: RDD[Edge[(BigDecimal,BigDecimal)]] = leadDf
       .select("from", "to", "from time", "to time")
@@ -36,6 +36,5 @@ object TopologyGraphGenerator {
           (row.getAs[BigDecimal]("from time"), row.getAs[BigDecimal]("to time"))))
 
     Graph(vertices, edges)
-
   }
-  }
+}

--- a/data-generation/src/main/scala/TopologyGraphGenerator.scala
+++ b/data-generation/src/main/scala/TopologyGraphGenerator.scala
@@ -21,7 +21,6 @@ object TopologyGraphGenerator {
       .withColumn("edgeId", last(col("id"), ignoreNulls = true).over(window.rowsBetween(Window.unboundedPreceding, 0)))
     val tempDf = df.groupBy("edgeId").agg(functions.min("time").alias("from time"), functions.max("time").alias("to time"))
     val leadDf = df.as("self1").join(tempDf.as("self2"), col("self1.id") === col("self2.edgeId"), "inner").select("from", "to", "from time", "to time")
-    leadDf.show()
     val vertices: RDD[(Long, Long)] = leadDf
       .select("from")
       .distinct

--- a/data-generation/src/main/scala/UpdateDistributions.scala
+++ b/data-generation/src/main/scala/UpdateDistributions.scala
@@ -1,0 +1,77 @@
+import breeze.plot.{Figure, hist}
+import breeze.stats.distributions.LogNormal
+import org.apache.spark.graphx.Graph
+
+object UpdateDistributions {
+
+
+  /** Add log normal distributed weights as the property for vertices
+   *
+   * @param g     Your graph
+   * @param mu    Expected value (Forventingsverdi)
+   * @param sigma Standard deviation(Eller varians?)
+   * @tparam VD VertexType
+   * @tparam ED EdgeType
+   * @return */
+  def add_log_normal_update_distr_vertex[VD, ED](g: Graph[VD, ED], mu: Int = 100, sigma: Double = 2): Graph[Int, ED] = {
+    g.mapVertices((_, _) => LogNormal(mu, sigma).draw().toInt)
+  }
+
+  /** Add log normal distributed weights as the property for vertices
+   *
+   * @param g     Your graph
+   * @param mu    Expected value (Forventingsverdi)
+   * @param sigma Standard deviation(Eller varians?)
+   * @tparam VD VertexType
+   * @tparam ED EdgeType
+   * @return */
+  def add_log_normal_update_distr_edge[VD, ED](g: Graph[VD, ED], mu: Int = 100, sigma: Double = 2): Graph[VD, Int] = {
+    g.mapEdges(_ => LogNormal(mu, sigma).draw().toInt)
+  }
+
+  /** Add log normal distributed weights as the property for vertices and edges
+   *
+   * Idk why this isn't just one function. TODO make a general function where the distribution can be inserted
+   * @param mu Expected value
+   * @param sigma Standard deviation (or variance?)
+   */
+  def add_log_normal_update_distr_graph[VD, ED](g: Graph[VD, ED], mu: Int = 100, sigma: Double = 2): Graph[Int, Int] = {
+    val g1 = add_log_normal_update_distr_vertex(g, mu, sigma)
+    add_log_normal_update_distr_edge(g1, mu, sigma)
+  }
+
+
+
+  /** Plot the distribution of the Int associated with vertices
+   *
+   * @param g        Your graph
+   * @param bins     Number of bins for the histogram
+   * @param title    Title for the generated diagram
+   * @param filename Filename for the diagram
+   * @tparam ED Edges can have any type */
+  def plotUpdateDistributionVertices[ED](g: Graph[Int, ED], bins: Int = 100, title: String = "Here your dist", filename: String = "plot.png"): Unit = {
+    val f = Figure()
+    val p = f.subplot(0)
+    p += hist(g.vertices.values.collect(), bins)
+    p.title = title
+    f.saveas(filename)
+  }
+
+  /** Plot the distribution of the Int associated with edges
+   *
+   * @param g        Your graph
+   * @param bins     Number of bins for the histogram
+   * @param title    Title for the generated diagram
+   * @param filename Filename for the diagram
+   * @tparam VD Vertices can have any type */
+  def plotUpdateDistributionEdges[VD](g: Graph[VD, Int], bins: Int = 100, title: String = "Here your dist", filename: String = "plot.png"): Unit = {
+    val f = Figure()
+    val p = f.subplot(0)
+    val h = g.edges.collect().map(x => x.attr.toDouble)
+    p += hist(h, bins)
+    p.title = title
+    f.saveas(filename)
+  }
+}
+
+

--- a/data-generation/src/main/scala/UpdateDistributions.scala
+++ b/data-generation/src/main/scala/UpdateDistributions.scala
@@ -32,7 +32,7 @@ object UpdateDistributions {
     val graphWithDegree = graph
       .vertices
       .zip(graph.ops.degrees)
-      .map(vertex => (vertex._1._1, vertex._2._2))
+      .map((_._1._1, _._2._2))
       .collect()
       .sortBy(vertexTuple => vertexTuple)(getVertexSorting(mode))
 

--- a/data-generation/src/main/scala/UpdateDistributions.scala
+++ b/data-generation/src/main/scala/UpdateDistributions.scala
@@ -36,7 +36,7 @@ object UpdateDistributions {
     val graphWithDegree = graph
       .vertices
       .zip(graph.ops.degrees)
-      .map((_._1._1, _._2._2))
+      .map(vertex => (vertex._1._1, vertex._2._2))
       .collect()
       .sortBy(vertexTuple => vertexTuple)(getVertexSorting(mode))
 
@@ -62,7 +62,7 @@ object UpdateDistributions {
    * */
   private def getVertexSorting(mode: CorrelationMode): Ordering[(VertexId, Int)] = {
     mode match {
-      case CorrelationMode.Uniform => (x: (VertexId, Int), y: (VertexId, Int)) => x._1 compareTo y._1
+      case CorrelationMode.Uniform => (x: (VertexId, Int), y: (VertexId, Int)) => x.hashCode() compareTo y.hashCode()
       case CorrelationMode.PositiveCorrelation => (x: (VertexId, Int), y: (VertexId, Int)) => x._2 compareTo y._2
       case CorrelationMode.NegativeCorrelation => (x: (VertexId, Int), y: (VertexId, Int)) => y._2 compareTo x._2
     }
@@ -74,8 +74,6 @@ object UpdateDistributions {
    * @param graph        A graph where vertices have a update count as a Int
    * @param mode         Mode for distributing the weights based on vertex degree
    * @param distribution Some probability distribution
-   * @param mu           Expected value
-   * @param sigma        Standard deviation
    * @return */
   def addEdgeUpdateDistribution[VD, ED: ClassTag](sc: SparkContext, graph: Graph[Int, ED], mode: CorrelationMode, distribution: DistributionType): Graph[Int, Int] = {
     val vertexUpdateHashMap = graph

--- a/data-generation/src/main/scala/UpdateDistributions.scala
+++ b/data-generation/src/main/scala/UpdateDistributions.scala
@@ -139,7 +139,6 @@ object UpdateDistributions {
    * TODO make a general function where the distribution can be inserted
    *
    * @param sc    A SparkContext
-   * @param graph A graph
    * @param mu    Expected value
    * @param sigma Standard deviation
    */
@@ -155,7 +154,7 @@ object UpdateDistributions {
    * @param title    Title for the generated diagram
    * @param filename Filename for the diagram
    * @tparam ED Edges can have any type */
-  def plotUpdateDistributionVertices[ED](graph: Graph[Int, ED], bins: Int = 100, title: String = "Here your dist", filename: String = "plot.png"): Unit = {
+  def plotUpdateDistributionVerticessss[ED](graph: Graph[Int, ED], bins: Int = 100, title: String = "Here your dist", filename: String = "plot.png"): Unit = {
     val figure = Figure()
     val plot = figure.subplot(0)
     plot += hist(graph.vertices.values.collect(), bins)

--- a/data-generation/src/main/scala/UpdateDistributions.scala
+++ b/data-generation/src/main/scala/UpdateDistributions.scala
@@ -3,13 +3,13 @@ import UpdateDistributionMode.UpdateDistributionMode
 import breeze.plot.{Figure, hist}
 import breeze.stats.distributions.{Gaussian, LogNormal}
 import org.apache.spark.SparkContext
-import org.apache.spark.graphx.{Graph, VertexId}
+import org.apache.spark.graphx.{Edge, Graph, VertexId}
 
 import scala.reflect.ClassTag
 
 object UpdateDistributionMode extends Enumeration {
   type UpdateDistributionMode = Value
-  val Uniform, HighDegreeSkew, LowDegreeSkew = Value
+  val Uniform, PositiveCorrelation, NegativeCorrelation = Value
 }
 
 object DistributionType extends Enumeration {
@@ -18,18 +18,6 @@ object DistributionType extends Enumeration {
 }
 
 object UpdateDistributions {
-
-  /** Add log normal distributed weights as the property for vertices
-   *
-   * @param graph A graph
-   * @param mu    Expected value
-   * @param sigma Standard deviation
-   * @tparam VD VertexType
-   * @tparam ED EdgeType
-   * @return */
-  def addLogNormalVertexUpdateDistribution[VD, ED](graph: Graph[VD, ED], mu: Int = 100, sigma: Double = 2): Graph[Int, ED] = {
-    graph.mapVertices((_, _) => LogNormal(mu, sigma).draw().toInt)
-  }
 
   /** Add an update count to all nodes
    *
@@ -46,7 +34,7 @@ object UpdateDistributions {
       .zip(graph.ops.degrees)
       .map(vertex => (vertex._1._1, vertex._2._2))
       .collect()
-      .sortBy(vertex => vertex)(withMode(mode))
+      .sortBy(vertexTuple => vertexTuple)(getVertexSorting(mode))
 
     val updates = graph.mapVertices((_, _) => getDistributionDraw(distribution, mu, sigma))
       .vertices.collect()
@@ -67,20 +55,75 @@ object UpdateDistributions {
    * @param mode Indicates the mode of which the nodes are ordered by
    * @return A Ordering function
    * */
-  private def withMode(mode: UpdateDistributionMode): Ordering[(VertexId, Int)] = {
+  private def getVertexSorting(mode: UpdateDistributionMode): Ordering[(VertexId, Int)] = {
     mode match {
       case UpdateDistributionMode.Uniform => (x: (VertexId, Int), y: (VertexId, Int)) => x._1 compareTo y._1
-      case UpdateDistributionMode.LowDegreeSkew => (x: (VertexId, Int), y: (VertexId, Int)) => x._2 compareTo y._2
-      case UpdateDistributionMode.HighDegreeSkew => (x: (VertexId, Int), y: (VertexId, Int)) => y._2 compareTo x._2
+      case UpdateDistributionMode.PositiveCorrelation => (x: (VertexId, Int), y: (VertexId, Int)) => x._2 compareTo y._2
+      case UpdateDistributionMode.NegativeCorrelation => (x: (VertexId, Int), y: (VertexId, Int)) => y._2 compareTo x._2
+    }
+  }
+
+  /** Add an update count to all edges
+   *
+   * @param sc           A SparkContext
+   * @param graph        A graph where vertices have a update count as a Int
+   * @param mode         Mode for distributing the weights based on vertex degree
+   * @param distribution Some probability distribution
+   * @param mu           Expected value
+   * @param sigma        Standard deviation
+   * @return */
+  def addEdgeUpdateDistribution[VD, ED: ClassTag](sc: SparkContext, graph: Graph[Int, ED], mode: UpdateDistributionMode, distribution: DistributionType, mu: Int, sigma: Double): Graph[Int, Int] = {
+    val vertexUpdateHashMap = graph
+      .vertices
+      .collect()
+      .toMap
+
+    val graphWithDegree = graph
+      .mapEdges(edge => getVertexUpdateSum[ED](edge, vertexUpdateHashMap))
+      .edges
+      .collect()
+      .sortBy(edge => edge)(getEdgeSorting(mode))
+
+    val updates = graph
+      .mapEdges(_ => getDistributionDraw(distribution, mu, sigma))
+      .edges
+      .collect()
+      .sortBy(edge => edge.attr)
+      .map(edge => edge.attr)
+
+    val rdd = sc.parallelize(
+      graphWithDegree
+        .zip(updates)
+        .map(edgeTuple => Edge(edgeTuple._1.srcId, edgeTuple._1.dstId, edgeTuple._2))
+    )
+    Graph[Int, Int](graph.vertices, rdd)
+  }
+
+  /**
+   *
+   * @param edge
+   * @param hashMap Hash map with vertices as keys and update counts as values
+   * @return The sum of updates of the edge's connected vertices
+   */
+  private def getVertexUpdateSum[ED](edge: Edge[ED], hashMap: Map[VertexId, Int]): Int = {
+    hashMap.getOrElse(edge.srcId, 0) + hashMap.getOrElse(edge.dstId, 0)
+  }
+
+  private def getEdgeSorting(mode: UpdateDistributionMode): Ordering[Edge[Int]] = {
+    mode match {
+      case UpdateDistributionMode.Uniform => (x: Edge[_], y: Edge[_]) => x.hashCode() compareTo y.hashCode()
+      case UpdateDistributionMode.PositiveCorrelation => (x: Edge[Int], y: Edge[Int]) => x.attr compareTo y.attr
+      case UpdateDistributionMode.NegativeCorrelation => (x: Edge[Int], y: Edge[Int]) => y.attr compareTo x.attr
     }
   }
 
   /** Draw a number from a probability distribution
+   *
    * @param distribution The type of probability distribution
-   * @param mu  Expected value
-   * @param sigma Standard deviation
-   * @return             A value in the distribution
-   * TODO: Make the input parameter agnostic - not only mu an sigma
+   * @param mu           Expected value
+   * @param sigma        Standard deviation
+   * @return A value in the distribution
+   *         TODO: Make the input parameter agnostic - not only mu and sigma
    * */
   private def getDistributionDraw(distribution: DistributionType, mu: Int, sigma: Double): Int = {
     distribution match {
@@ -89,30 +132,21 @@ object UpdateDistributions {
     }
   }
 
-  /** Add log normal distributed weights as the property for vertices
-   *
-   * @param graph A graph
-   * @param mu    Expected value
-   * @param sigma Standard deviation
-   * @tparam VD VertexType
-   * @tparam ED EdgeType
-   * @return */
-  def addLogNormalEdgeUpdateDistribution[VD, ED](graph: Graph[VD, ED], mu: Int = 100, sigma: Double = 2): Graph[VD, Int] = {
-    graph.mapEdges(_ => LogNormal(mu, sigma).draw().toInt)
-  }
 
   /** Add log normal distributed weights as the property for vertices and edges
    *
-   * Idk why this isn't just one function. TODO make a general function where the distribution can be inserted
+   * Idk why this isn't just one function.
+   * TODO make a general function where the distribution can be inserted
    *
+   * @param sc    A SparkContext
+   * @param graph A graph
    * @param mu    Expected value
    * @param sigma Standard deviation
    */
-  def addLogNormalGraphUpdateDistribution[VD, ED](g: Graph[VD, ED], mu: Int = 100, sigma: Double = 2): Graph[Int, Int] = {
-    val g1 = addLogNormalVertexUpdateDistribution(g, mu, sigma)
-    addLogNormalEdgeUpdateDistribution(g1, mu, sigma)
+  def addLogNormalGraphUpdateDistribution[VD, ED: ClassTag](sc: SparkContext, graph: Graph[VD, ED], mu: Int = 100, sigma: Double = 2): Graph[Int, Int] = {
+    val g1 = addVertexUpdateDistribution(sc, graph, UpdateDistributionMode.PositiveCorrelation, DistributionType.LogNormal, mu, sigma)
+    addEdgeUpdateDistribution(sc, g1, UpdateDistributionMode.PositiveCorrelation, DistributionType.LogNormal, mu, sigma)
   }
-
 
   /** Plot the distribution of the Int associated with vertices
    *
@@ -136,13 +170,13 @@ object UpdateDistributions {
    * @param title    Title for the generated diagram
    * @param filename Filename for the diagram
    * @tparam VD Vertices can have any type */
-  def plotUpdateDistributionEdges[VD](g: Graph[VD, Int], bins: Int = 100, title: String = "Here your dist", filename: String = "plot.png"): Unit = {
-    val f = Figure()
-    val p = f.subplot(0)
-    val h = g.edges.collect().map(x => x.attr.toDouble)
-    p += hist(h, bins)
-    p.title = title
-    f.saveas(filename)
+  def plotUpdateDistributionEdges[VD](graph: Graph[VD, Int], bins: Int = 100, title: String = "Here your dist", filename: String = "plot.png"): Unit = {
+    val figure = Figure()
+    val plot = figure.subplot(0)
+    val values = graph.edges.collect().map(x => x.attr.toDouble)
+    plot += hist(values, bins)
+    plot.title = title
+    figure.saveas(filename)
   }
 }
 


### PR DESCRIPTION
Adds functions for adding an update count to edges and vertices of a graph.
Currently all properties on edges and vertices are overwritten, so a TODO would be to make the functions generic enough that it just extends the current graph with an update count.

The update counts for vertices can be correlated with the vertex degree in these ways:
* Uniform: The correlation between vertex degree and updates are 0
* PositiveCorrelation: The correlation between vertex degree and updates is > 0
* NegativeCorrelation: The correlation between vertex degree and updates is < 0  

The update counts for vertices can be correlated with the sum of the edge's nodes' update counts in these ways:
* Uniform: The correlation between node sums and edge update count is 0
* PositiveCorrelation: The correlation between node sums and edge update count is > 0
* NegativeCorrelation: The correlation between node sums and edge update count is < 0 