### PR TITLE
chore: ci only on pushes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,6 @@
 name: Scala CI
 
 on:
-  pull_request:
-    branches:
-      - main
   push:
 
 jobs:


### PR DESCRIPTION
CI blir kjørt dobbelt opp. Tror det fikses ved å endre til kun pushes. Lager PR for å forsikre meg om at det kjøres kun én gang