### PR TITLE
Add Landy model that extends TemporalGraph

### DIFF
--- a/data-generation/src/main/scala/factories/LandyGraphFactory.scala
+++ b/data-generation/src/main/scala/factories/LandyGraphFactory.scala
@@ -1,0 +1,84 @@
+package factories
+
+import org.apache.spark.graphx.{Edge, Graph}
+import org.apache.spark.sql.SparkSession
+import thesis.{LandyEdgePayload, LandyVertexPayload}
+import thesis.SnapshotDeltaObject.LandyAttributeGraph
+import thesis.SparkConfiguration.getSparkSession
+
+import java.time.Instant
+import scala.collection.immutable.HashMap
+
+object LandyGraphFactory {
+  def createGraph(): LandyAttributeGraph = {
+    val spark: SparkSession = getSparkSession
+
+    val vertices = spark.sparkContext.parallelize(getVertices)
+    val edges = spark.sparkContext.parallelize(getEdges)
+
+    Graph(vertices, edges)
+  }
+  val t1 = Instant.parse("2000-01-01T00:00:00.000Z")
+  val t2 = Instant.parse("2001-01-01T00:00:00.000Z")
+  val t3 = Instant.parse("2002-01-01T00:00:00.000Z")
+  def getVertices(): Seq[(Long, LandyVertexPayload)] = {
+
+    Seq(
+      (1000L,
+        LandyVertexPayload(
+          id = 1L,
+          validFrom = t1,
+          validTo = t2,
+          attributes = HashMap(
+            "color"->"red",
+          )
+        )
+      ),
+      (1001L,
+        LandyVertexPayload(
+          id = 1L,
+          validFrom = t2,
+          validTo = t3,
+          attributes = HashMap(
+            "color"->"orange",
+          )
+        )
+      ),
+      (1002L,
+        LandyVertexPayload(
+          id = 2L,
+          validFrom = t1,
+          validTo = t3,
+          attributes = HashMap(
+            "color"->"red",
+          )
+        )
+      )
+    )
+  }
+
+  def getEdges(): Seq[Edge[LandyEdgePayload]] = {
+    Seq(
+      Edge(1L, 2L,
+        LandyEdgePayload(
+          id = 1003L,
+          validFrom = t1,
+          validTo = t2,
+          attributes = HashMap(
+            "relation"->"brother"
+          )
+        )
+      ),
+      Edge(1L, 2L,
+        LandyEdgePayload(
+          id = 1004L,
+          validFrom = t2,
+          validTo = t3,
+          attributes = HashMap(
+            "relation"->"brother"
+          )
+        )
+      )
+    )
+  }
+}

--- a/data-generation/src/main/scala/thesis/Landy.scala
+++ b/data-generation/src/main/scala/thesis/Landy.scala
@@ -3,7 +3,7 @@ package thesis
 import org.apache.spark.graphx.{EdgeRDD, EdgeTriplet, Graph, VertexRDD}
 import org.apache.spark.rdd.RDD
 import thesis.LTSV.Attributes
-import thesis.SnapshotDeltaObject.G
+import thesis.SnapshotDeltaObject.AttributeGraph
 
 import java.time.Instant
 
@@ -12,7 +12,8 @@ final case class InvalidTimeSchemaError(
                                          private val cause: Throwable = None.orNull
                                        ) extends IllegalStateException(message, cause)
 
-class Landy(val graph: G) extends TemporalGraph[Attributes, Attributes] {
+
+class Landy(val graph: AttributeGraph) extends TemporalGraph[Attributes, Attributes] {
   override val vertices: VertexRDD[Attributes] = graph.vertices
   override val edges: EdgeRDD[Attributes] = graph.edges
   override val triplets: RDD[EdgeTriplet[Attributes, Attributes]] = graph.triplets
@@ -21,6 +22,9 @@ class Landy(val graph: G) extends TemporalGraph[Attributes, Attributes] {
     val vertices = this.vertices.filter(vertex => (vertex._2.get("validFrom"), vertex._2.get("validTo")) match {
       case (Some(validFrom), Some(validTo)) => Instant.parse(validFrom).isBefore(instant) && (Instant.parse(validTo).isBefore(instant) || Instant.parse(validTo).equals(instant))
       case _ => throw new InvalidTimeSchemaError
+    }).map(vertex => vertex._2.get("vertexId") match {
+      case Some(value) => (value.toLong, vertex._2)
+      case None => throw new IllegalStateException("Vertices must have the original id stuff")
     })
 
     val edges = this.edges.filter(edge => (edge.attr.get("validFrom"), edge.attr.get("validTo")) match {

--- a/data-generation/src/main/scala/thesis/Landy.scala
+++ b/data-generation/src/main/scala/thesis/Landy.scala
@@ -1,37 +1,34 @@
 package thesis
 
-import org.apache.spark.graphx.{EdgeRDD, EdgeTriplet, Graph, VertexRDD}
+import org.apache.spark.graphx.{Edge, EdgeRDD, EdgeTriplet, Graph, VertexRDD}
 import org.apache.spark.rdd.RDD
 import thesis.LTSV.Attributes
-import thesis.SnapshotDeltaObject.AttributeGraph
+import thesis.SnapshotDeltaObject.LandyAttributeGraph
 
 import java.time.Instant
 
-final case class InvalidTimeSchemaError(
-                                         private val message: String = "All Landy objects should have validFrom and validTo as attributes.",
-                                         private val cause: Throwable = None.orNull
-                                       ) extends IllegalStateException(message, cause)
+case class LandyVertexPayload(id: Long, validFrom: Instant, validTo:Instant, attributes:Attributes)
+case class LandyEdgePayload(id: Long, validFrom: Instant, validTo:Instant, attributes:Attributes)
 
 
-class Landy(val graph: AttributeGraph) extends TemporalGraph[Attributes, Attributes] {
-  override val vertices: VertexRDD[Attributes] = graph.vertices
-  override val edges: EdgeRDD[Attributes] = graph.edges
-  override val triplets: RDD[EdgeTriplet[Attributes, Attributes]] = graph.triplets
+class Landy(val graph: LandyAttributeGraph) extends TemporalGraph[LandyVertexPayload, LandyEdgePayload] {
 
-  override def snapshotAtTime(instant: Instant): Graph[Attributes, Attributes] = {
-    val vertices = this.vertices.filter(vertex => (vertex._2.get("validFrom"), vertex._2.get("validTo")) match {
-      case (Some(validFrom), Some(validTo)) => Instant.parse(validFrom).isBefore(instant) && (Instant.parse(validTo).isBefore(instant) || Instant.parse(validTo).equals(instant))
-      case _ => throw new InvalidTimeSchemaError
-    }).map(vertex => vertex._2.get("vertexId") match {
-      case Some(value) => (value.toLong, vertex._2)
-      case None => throw new IllegalStateException("Vertices must have the original id stuff")
-    })
+  override val vertices: VertexRDD[LandyVertexPayload] = graph.vertices
+  override val edges: EdgeRDD[LandyEdgePayload] = graph.edges
+  override val triplets: RDD[EdgeTriplet[LandyVertexPayload, LandyEdgePayload]] = graph.triplets
 
-    val edges = this.edges.filter(edge => (edge.attr.get("validFrom"), edge.attr.get("validTo")) match {
-      case (Some(validFrom), Some(validTo)) => Instant.parse(validFrom).isBefore(instant) && (Instant.parse(validTo).isBefore(instant) || Instant.parse(validTo).equals(instant))
-      case _ => throw new InvalidTimeSchemaError
-    })
+  override def snapshotAtTime(instant: Instant): Graph[LandyVertexPayload, LandyEdgePayload] = {
 
+    val vertices = this.vertices.filter(vertex =>
+      vertex._2 != null && // Required since the vertex payload is null when "floating edges" are created
+      vertex._2.validFrom.isBefore(instant) &&
+      vertex._2.validTo.isBefore(instant) || vertex._2.validTo.equals(instant)
+    ).map(vertex => (vertex._2.id, vertex._2))
+
+    val edges = this.edges.filter(edge =>
+        edge.attr.validFrom.isBefore(instant) &&
+        edge.attr.validTo.isBefore(instant) || edge.attr.validTo.equals(instant)
+      )
     Graph(vertices, edges)
   }
 }

--- a/data-generation/src/main/scala/thesis/Landy.scala
+++ b/data-generation/src/main/scala/thesis/Landy.scala
@@ -14,16 +14,18 @@ class Landy(val graph: G) extends TemporalGraph[Attributes, Attributes] {
   override val triplets: RDD[EdgeTriplet[Attributes, Attributes]] = graph.triplets
 
   override def snapshotAtTime(instant: Instant): Graph[Attributes, Attributes] = {
-    val vertices = this.vertices.filter(vertex => (vertex._2.get("timeFrom"), vertex._2.get("timeTo")) match {
-      case (Some(timeFrom), Some(timeTo)) => Instant.parse(timeFrom).isBefore(instant) && Instant.parse(timeTo).isBefore(instant)
-      case _ => throw new IllegalStateException("All Landy objects should have timeFrom and timeTo as attributes.")
+    val vertices = this.vertices.filter(vertex => (vertex._2.get("validFrom"), vertex._2.get("validTo")) match {
+      case (Some(validFrom), Some(validTo)) => Instant.parse(validFrom).isBefore(instant) && (Instant.parse(validTo).isBefore(instant) || Instant.parse(validTo).equals(instant))
+      case _ => throw new IllegalStateException("All Landy objects should have validFrom and validTo as attributes.")
     })
 
-    val edges = this.edges.filter(edge => (edge.attr.get("timeFrom"), edge.attr.get("timeTo")) match {
-      case (Some(timeFrom), Some(timeTo)) => Instant.parse(timeFrom).isBefore(instant) && Instant.parse(timeTo).isBefore(instant)
-      case _ => throw new IllegalStateException("All Landy objects should have timeFrom and timeTo as attributes.")
+    val edges = this.edges.filter(edge => (edge.attr.get("validFrom"), edge.attr.get("validTo")) match {
+      case (Some(validFrom), Some(validTo)) => Instant.parse(validFrom).isBefore(instant) && (Instant.parse(validTo).isBefore(instant) || Instant.parse(validTo).equals(instant))
+      case _ => throw new IllegalStateException("All Landy objects should have validFrom and validTo as attributes.")
     })
 
     Graph(vertices, edges)
   }
 }
+
+

--- a/data-generation/src/main/scala/thesis/Landy.scala
+++ b/data-generation/src/main/scala/thesis/Landy.scala
@@ -1,0 +1,29 @@
+package thesis
+
+import org.apache.spark.graphx.{EdgeRDD, EdgeTriplet, Graph, VertexRDD}
+import org.apache.spark.rdd.RDD
+import thesis.LTSV.Attributes
+import thesis.SnapshotDeltaObject.G
+
+import java.time.Instant
+
+
+class Landy(val graph: G) extends TemporalGraph[Attributes, Attributes] {
+  override val vertices: VertexRDD[Attributes] = graph.vertices
+  override val edges: EdgeRDD[Attributes] = graph.edges
+  override val triplets: RDD[EdgeTriplet[Attributes, Attributes]] = graph.triplets
+
+  override def snapshotAtTime(instant: Instant): Graph[Attributes, Attributes] = {
+    val vertices = this.vertices.filter(vertex => (vertex._2.get("timeFrom"), vertex._2.get("timeTo")) match {
+      case (Some(timeFrom), Some(timeTo)) => Instant.parse(timeFrom).isBefore(instant) && Instant.parse(timeTo).isBefore(instant)
+      case _ => throw new IllegalStateException("All Landy objects should have timeFrom and timeTo as attributes.")
+    })
+
+    val edges = this.edges.filter(edge => (edge.attr.get("timeFrom"), edge.attr.get("timeTo")) match {
+      case (Some(timeFrom), Some(timeTo)) => Instant.parse(timeFrom).isBefore(instant) && Instant.parse(timeTo).isBefore(instant)
+      case _ => throw new IllegalStateException("All Landy objects should have timeFrom and timeTo as attributes.")
+    })
+
+    Graph(vertices, edges)
+  }
+}

--- a/data-generation/src/main/scala/thesis/SnapshotDelta.scala
+++ b/data-generation/src/main/scala/thesis/SnapshotDelta.scala
@@ -333,6 +333,7 @@ object SnapshotDeltaObject {
     } else {
       snapshot2
     }
-
   type AttributeGraph = Graph[Attributes, Attributes]
+  type LandyAttributeGraph = Graph[LandyVertexPayload, LandyEdgePayload]
+
 }

--- a/data-generation/src/main/scala/thesis/SnapshotDelta.scala
+++ b/data-generation/src/main/scala/thesis/SnapshotDelta.scala
@@ -33,16 +33,16 @@ class SnapshotDelta(val graphs: MutableList[Snapshot],
   override val triplets: RDD[EdgeTriplet[Attributes, Attributes]] = graphs.get(0).get.graph.triplets
   val logger: Logger = getLogger
 
-  def forwardApplyLogs(graph: G, logsToApply: RDD[LogTSV]): G = {
+  def forwardApplyLogs(graph: AttributeGraph, logsToApply: RDD[LogTSV]): AttributeGraph = {
     Graph(
       applyVertexLogsToSnapshot(graph, logsToApply),
       applyEdgeLogsToSnapshot(graph, logsToApply)
     )
   }
 
-  def backwardsApplyLogs(g: G, logsToApply: RDD[LogTSV]): G = throw new NotImplementedError()
+  def backwardsApplyLogs(g: AttributeGraph, logsToApply: RDD[LogTSV]): AttributeGraph = throw new NotImplementedError()
 
-  override def snapshotAtTime(instant: Instant): G = {
+  override def snapshotAtTime(instant: Instant): AttributeGraph = {
 
     val closestGraph = graphs.reduce(returnClosestGraph(instant))
     logger.warn(s"Instant $instant, Closest :graph${closestGraph.instant}")
@@ -109,7 +109,7 @@ object SnapshotIntervalType {
   final case class Count(numberOfActions: Int) extends SnapshotIntervalType
 }
 
-final case class Snapshot(graph: G, instant: Instant)
+final case class Snapshot(graph: AttributeGraph, instant: Instant)
 
 object SnapshotDeltaObject {
   def getLogger: Logger = LoggerFactory.getLogger("SnapShotDelta")
@@ -334,6 +334,5 @@ object SnapshotDeltaObject {
       snapshot2
     }
 
-  type G = Graph[Attributes, Attributes]
-
+  type AttributeGraph = Graph[Attributes, Attributes]
 }

--- a/data-generation/src/test/scala/LandySpec.scala
+++ b/data-generation/src/test/scala/LandySpec.scala
@@ -56,11 +56,18 @@ class LandySpec extends AnyFlatSpec with SparkTestWrapper {
 
   "Landy" can "be created" in {
     val landy: Landy = new Landy(createGraph())
+
+    assert(landy.vertices.count() == 3)
+    assert(landy.edges.count() == 2)
+  }
+
+  it can "give a snapshot" in {
+    val landy: Landy = new Landy(createGraph())
     val instant = Instant.parse(t2)
+
     val graph = landy.snapshotAtTime(instant)
 
     assert(graph.vertices.count() == 2)
     assert(graph.edges.count() == 1)
   }
-
 }

--- a/data-generation/src/test/scala/LandySpec.scala
+++ b/data-generation/src/test/scala/LandySpec.scala
@@ -1,8 +1,8 @@
 import org.apache.spark.graphx.{Edge, Graph, VertexRDD}
-import thesis.Landy
+import thesis.{Landy, LandyEdgePayload, LandyVertexPayload}
 import org.scalatest.flatspec.AnyFlatSpec
 import thesis.LTSV.Attributes
-import thesis.SnapshotDeltaObject.AttributeGraph
+import thesis.SnapshotDeltaObject.LandyAttributeGraph
 import wrappers.SparkTestWrapper
 
 import java.time.Instant
@@ -10,50 +10,72 @@ import scala.collection.immutable.HashMap
 
 class LandySpec extends AnyFlatSpec with SparkTestWrapper {
 
-  def createGraph(): AttributeGraph = {
+  def createGraph(): LandyAttributeGraph = {
     val vertices = spark.sparkContext.parallelize(getVertices)
     val edges = spark.sparkContext.parallelize(getEdges)
+
     Graph(vertices, edges)
   }
-  val t1 = "2000-01-01T00:00:00.000Z"
-  val t2 = "2001-01-01T00:00:00.000Z"
-  val t3 = "2002-01-01T00:00:00.000Z"
-  def getVertices(): Seq[(Long, Attributes)] = {
+  val t1 = Instant.parse("2000-01-01T00:00:00.000Z")
+  val t2 = Instant.parse("2001-01-01T00:00:00.000Z")
+  val t3 = Instant.parse("2002-01-01T00:00:00.000Z")
+  def getVertices(): Seq[(Long, LandyVertexPayload)] = {
 
     Seq(
-      (1L, HashMap(
-        "validFrom"->t1,
-        "validTo"->t2,
-        "color"->"red",
-        "vertexId"->"1"
-      )
+      (1000L,
+        LandyVertexPayload(
+          id = 1L,
+          validFrom = t1,
+          validTo = t2,
+          attributes = HashMap(
+            "color"->"red",
+          )
+        )
       ),
-      (2L, HashMap(
-        "validFrom"->t2,
-        "validTo"->t3,
-        "color"->"blue",
-        "vertexId"->"1"
-      )),
-      (3L, HashMap(
-        "validFrom"->t1,
-        "validTo"->t3,
-        "color"->"orange",
-        "vertexId"->"2"
-      ))
+      (1001L,
+        LandyVertexPayload(
+          id = 1L,
+          validFrom = t2,
+          validTo = t3,
+          attributes = HashMap(
+            "color"->"orange",
+          )
+        )
+      ),
+      (1002L,
+        LandyVertexPayload(
+          id = 2L,
+          validFrom = t1,
+          validTo = t3,
+          attributes = HashMap(
+            "color"->"red",
+          )
+        )
+      )
     )
   }
 
-  def getEdges(): Seq[Edge[Attributes]] = {
+  def getEdges(): Seq[Edge[LandyEdgePayload]] = {
     Seq(
-      Edge(1L, 3L, HashMap(
-        "validFrom"->t1,
-        "validTo"->t2,
-        "relation"->"brother")
-    ),
-      Edge(2L, 3L, HashMap(
-        "validFrom"->t2,
-        "validTo"->t3,
-        "color"->"sister")
+      Edge(1L, 2L,
+        LandyEdgePayload(
+          id = 1003L,
+          validFrom = t1,
+          validTo = t2,
+          attributes = HashMap(
+            "relation"->"brother"
+          )
+        )
+      ),
+      Edge(1L, 2L,
+        LandyEdgePayload(
+          id = 1004L,
+          validFrom = t2,
+          validTo = t3,
+          attributes = HashMap(
+            "relation"->"brother"
+          )
+        )
       )
     )
   }
@@ -61,15 +83,14 @@ class LandySpec extends AnyFlatSpec with SparkTestWrapper {
   "Landy" can "be created" in {
     val landy: Landy = new Landy(createGraph())
 
-    assert(landy.vertices.count() == 3)
+    assert(landy.vertices.count() == 5)
     assert(landy.edges.count() == 2)
   }
 
   it can "give a snapshot" in {
     val landy: Landy = new Landy(createGraph())
-    val instant = Instant.parse(t2)
 
-    val graph = landy.snapshotAtTime(instant)
+    val graph = landy.snapshotAtTime(t2)
 
     assert(graph.vertices.count() == 2)
     assert(graph.edges.count() == 1)

--- a/data-generation/src/test/scala/LandySpec.scala
+++ b/data-generation/src/test/scala/LandySpec.scala
@@ -1,0 +1,66 @@
+import org.apache.spark.graphx.{Edge, Graph, VertexRDD}
+import thesis.Landy
+import org.scalatest.flatspec.AnyFlatSpec
+import thesis.LTSV.Attributes
+import thesis.SnapshotDeltaObject.G
+import wrappers.SparkTestWrapper
+
+import java.time.Instant
+import scala.collection.immutable.HashMap
+
+class LandySpec extends AnyFlatSpec with SparkTestWrapper {
+
+  def createGraph(): G = {
+    val vertices = spark.sparkContext.parallelize(getVertices)
+    val edges = spark.sparkContext.parallelize(getEdges)
+    Graph(vertices, edges)
+  }
+  val t1 = "2000-01-01T00:00:00.000Z"
+  val t2 = "2001-01-01T00:00:00.000Z"
+  val t3 = "2002-01-01T00:00:00.000Z"
+  def getVertices(): Seq[(Long, Attributes)] = {
+
+    Seq(
+      (1L, HashMap(
+        "validFrom"->t1,
+        "validTo"->t2,
+        "color"->"red")
+      ),
+      (2L, HashMap(
+        "validFrom"->t2,
+        "validTo"->t3,
+        "color"->"blue"
+      )),
+      (3L, HashMap(
+        "validFrom"->t1,
+        "validTo"->t3,
+        "color"->"orange"
+      ))
+    )
+  }
+
+  def getEdges(): Seq[Edge[Attributes]] = {
+    Seq(
+      Edge(1L, 3L, HashMap(
+        "validFrom"->t1,
+        "validTo"->t2,
+        "relation"->"brother")
+    ),
+      Edge(2L, 3L, HashMap(
+        "validFrom"->t2,
+        "validTo"->t3,
+        "color"->"sister")
+      )
+    )
+  }
+
+  "Landy" can "be created" in {
+    val landy: Landy = new Landy(createGraph())
+    val instant = Instant.parse(t2)
+    val graph = landy.snapshotAtTime(instant)
+
+    assert(graph.vertices.count() == 2)
+    assert(graph.edges.count() == 1)
+  }
+
+}

--- a/data-generation/src/test/scala/LandySpec.scala
+++ b/data-generation/src/test/scala/LandySpec.scala
@@ -2,7 +2,7 @@ import org.apache.spark.graphx.{Edge, Graph, VertexRDD}
 import thesis.Landy
 import org.scalatest.flatspec.AnyFlatSpec
 import thesis.LTSV.Attributes
-import thesis.SnapshotDeltaObject.G
+import thesis.SnapshotDeltaObject.AttributeGraph
 import wrappers.SparkTestWrapper
 
 import java.time.Instant
@@ -10,7 +10,7 @@ import scala.collection.immutable.HashMap
 
 class LandySpec extends AnyFlatSpec with SparkTestWrapper {
 
-  def createGraph(): G = {
+  def createGraph(): AttributeGraph = {
     val vertices = spark.sparkContext.parallelize(getVertices)
     val edges = spark.sparkContext.parallelize(getEdges)
     Graph(vertices, edges)
@@ -24,17 +24,21 @@ class LandySpec extends AnyFlatSpec with SparkTestWrapper {
       (1L, HashMap(
         "validFrom"->t1,
         "validTo"->t2,
-        "color"->"red")
+        "color"->"red",
+        "vertexId"->"1"
+      )
       ),
       (2L, HashMap(
         "validFrom"->t2,
         "validTo"->t3,
-        "color"->"blue"
+        "color"->"blue",
+        "vertexId"->"1"
       )),
       (3L, HashMap(
         "validFrom"->t1,
         "validTo"->t3,
-        "color"->"orange"
+        "color"->"orange",
+        "vertexId"->"2"
       ))
     )
   }

--- a/data-generation/src/test/scala/LandySpec.scala
+++ b/data-generation/src/test/scala/LandySpec.scala
@@ -1,87 +1,14 @@
-import org.apache.spark.graphx.{Edge, Graph, VertexRDD}
-import thesis.{Landy, LandyEdgePayload, LandyVertexPayload}
+import factories.LandyGraphFactory
+import factories.LandyGraphFactory.createGraph
+import thesis.Landy
 import org.scalatest.flatspec.AnyFlatSpec
-import thesis.LTSV.Attributes
-import thesis.SnapshotDeltaObject.LandyAttributeGraph
 import wrappers.SparkTestWrapper
 
-import java.time.Instant
-import scala.collection.immutable.HashMap
 
 class LandySpec extends AnyFlatSpec with SparkTestWrapper {
 
-  def createGraph(): LandyAttributeGraph = {
-    val vertices = spark.sparkContext.parallelize(getVertices)
-    val edges = spark.sparkContext.parallelize(getEdges)
-
-    Graph(vertices, edges)
-  }
-  val t1 = Instant.parse("2000-01-01T00:00:00.000Z")
-  val t2 = Instant.parse("2001-01-01T00:00:00.000Z")
-  val t3 = Instant.parse("2002-01-01T00:00:00.000Z")
-  def getVertices(): Seq[(Long, LandyVertexPayload)] = {
-
-    Seq(
-      (1000L,
-        LandyVertexPayload(
-          id = 1L,
-          validFrom = t1,
-          validTo = t2,
-          attributes = HashMap(
-            "color"->"red",
-          )
-        )
-      ),
-      (1001L,
-        LandyVertexPayload(
-          id = 1L,
-          validFrom = t2,
-          validTo = t3,
-          attributes = HashMap(
-            "color"->"orange",
-          )
-        )
-      ),
-      (1002L,
-        LandyVertexPayload(
-          id = 2L,
-          validFrom = t1,
-          validTo = t3,
-          attributes = HashMap(
-            "color"->"red",
-          )
-        )
-      )
-    )
-  }
-
-  def getEdges(): Seq[Edge[LandyEdgePayload]] = {
-    Seq(
-      Edge(1L, 2L,
-        LandyEdgePayload(
-          id = 1003L,
-          validFrom = t1,
-          validTo = t2,
-          attributes = HashMap(
-            "relation"->"brother"
-          )
-        )
-      ),
-      Edge(1L, 2L,
-        LandyEdgePayload(
-          id = 1004L,
-          validFrom = t2,
-          validTo = t3,
-          attributes = HashMap(
-            "relation"->"brother"
-          )
-        )
-      )
-    )
-  }
-
   "Landy" can "be created" in {
-    val landy: Landy = new Landy(createGraph())
+    val landy: Landy = new Landy(LandyGraphFactory.createGraph())
 
     assert(landy.vertices.count() == 5)
     assert(landy.edges.count() == 2)
@@ -90,7 +17,7 @@ class LandySpec extends AnyFlatSpec with SparkTestWrapper {
   it can "give a snapshot" in {
     val landy: Landy = new Landy(createGraph())
 
-    val graph = landy.snapshotAtTime(t2)
+    val graph = landy.snapshotAtTime(LandyGraphFactory.t2)
 
     assert(graph.vertices.count() == 2)
     assert(graph.edges.count() == 1)


### PR DESCRIPTION
Legger til Landy-modell med snapshotAtTimeT-funksjonen implementert. Jobber videre med en LandyConsumer, men tenker det kan komme i en annen PR.

## Diskusjon
Pr. nå gjør jeg bare en antakelse om at alle noder og kanter har `validFrom` og `validTo` som attributter. Vi må nok trikse litt på `Attributes` eller endre typene på `TemporalGraph` til å være mer generelle dersom vi skal gjøre typingen strengere.


## Testing
Har laget en basic test for Landy. Men jeg hardkodet grafen i samme test suite, vet ikke om det er noen bedre måte å gjøre det på? Ekstrahere det til en LandyGraphFactory? 🤪 