### PR TITLE
Fix implemenation of snapshotAtTime for SnapshotDelta

### DIFF
--- a/data-generation/src/main/scala/factories/LandyGraphFactory.scala
+++ b/data-generation/src/main/scala/factories/LandyGraphFactory.scala
@@ -2,9 +2,9 @@ package factories
 
 import org.apache.spark.graphx.{Edge, Graph}
 import org.apache.spark.sql.SparkSession
-import thesis.{LandyEdgePayload, LandyVertexPayload}
-import thesis.SnapshotDeltaObject.LandyAttributeGraph
+import thesis.DataTypes.LandyAttributeGraph
 import thesis.SparkConfiguration.getSparkSession
+import thesis.{LandyEdgePayload, LandyVertexPayload}
 
 import java.time.Instant
 import scala.collection.immutable.HashMap
@@ -18,9 +18,11 @@ object LandyGraphFactory {
 
     Graph(vertices, edges)
   }
+
   val t1 = Instant.parse("2000-01-01T00:00:00.000Z")
   val t2 = Instant.parse("2001-01-01T00:00:00.000Z")
   val t3 = Instant.parse("2002-01-01T00:00:00.000Z")
+
   def getVertices(): Seq[(Long, LandyVertexPayload)] = {
 
     Seq(
@@ -30,7 +32,7 @@ object LandyGraphFactory {
           validFrom = t1,
           validTo = t2,
           attributes = HashMap(
-            "color"->"red",
+            "color" -> "red",
           )
         )
       ),
@@ -40,7 +42,7 @@ object LandyGraphFactory {
           validFrom = t2,
           validTo = t3,
           attributes = HashMap(
-            "color"->"orange",
+            "color" -> "orange",
           )
         )
       ),
@@ -50,7 +52,7 @@ object LandyGraphFactory {
           validFrom = t1,
           validTo = t3,
           attributes = HashMap(
-            "color"->"red",
+            "color" -> "red",
           )
         )
       )
@@ -65,7 +67,7 @@ object LandyGraphFactory {
           validFrom = t1,
           validTo = t2,
           attributes = HashMap(
-            "relation"->"brother"
+            "relation" -> "brother"
           )
         )
       ),
@@ -75,7 +77,7 @@ object LandyGraphFactory {
           validFrom = t2,
           validTo = t3,
           attributes = HashMap(
-            "relation"->"brother"
+            "relation" -> "brother"
           )
         )
       )

--- a/data-generation/src/main/scala/factories/LogFactory.scala
+++ b/data-generation/src/main/scala/factories/LogFactory.scala
@@ -3,8 +3,8 @@ package factories
 import com.github.javafaker.Faker
 import org.apache.spark.graphx.VertexId
 import thesis.Action.{CREATE, DELETE, UPDATE}
+import thesis.DataTypes.Attributes
 import thesis.Entity.{EDGE, VERTEX}
-import thesis.LTSV.Attributes
 import thesis.{Action, Entity, LogTSV}
 import utils.TimeUtils
 

--- a/data-generation/src/main/scala/thesis/DataTypes.scala
+++ b/data-generation/src/main/scala/thesis/DataTypes.scala
@@ -1,0 +1,105 @@
+package thesis
+
+import org.apache.spark.graphx.Graph
+import thesis.DataTypes.{AttributeGraph, Attributes, EdgeId}
+
+import java.time.Instant
+import scala.collection.immutable
+
+object DataTypes {
+  //SnapshotDeltaGraph
+  type AttributeGraph = Graph[Attributes, SnapshotEdgePayload]
+  //LandyGraph
+  type LandyAttributeGraph = Graph[LandyVertexPayload, LandyEdgePayload]
+  // Type alias
+  type Attributes = immutable.HashMap[String, String]
+  // Like VertexId but for Edges since we are in dire need of a surrogate
+  type EdgeId = Long
+}
+
+case class Interval(start: Instant, stop: Instant)
+
+case class SnapshotEdgePayload(id: EdgeId, attributes: Attributes)
+
+
+sealed abstract class SnapshotIntervalType
+
+object SnapshotIntervalType {
+  final case class Time(duration: Int) extends SnapshotIntervalType
+
+  final case class Count(numberOfActions: Int) extends SnapshotIntervalType
+}
+
+final case class Snapshot(graph: AttributeGraph, instant: Instant)
+
+case class LandyVertexPayload(id: Long, validFrom: Instant, validTo: Instant, attributes: Attributes)
+
+case class LandyEdgePayload(id: Long, validFrom: Instant, validTo: Instant, attributes: Attributes)
+
+sealed abstract class DataSource
+
+object DataSource {
+  final case object Reptilian extends DataSource
+
+  final case object FbMessages extends DataSource
+
+}
+
+sealed abstract class CorrelationMode
+
+object CorrelationMode {
+  final case object Uniform extends CorrelationMode
+
+  final case object PositiveCorrelation extends CorrelationMode
+
+  final case object NegativeCorrelation extends CorrelationMode
+}
+
+sealed abstract class DistributionType
+
+object DistributionType {
+  final case class LogNormalType(mu: Int, sigma: Double) extends DistributionType
+
+  final case class GaussianType(mu: Int, sigma: Double) extends DistributionType
+
+  final case class UniformType(low: Double, high: Double) extends DistributionType
+}
+
+final case class IntervalAndUpdateCount(interval: Interval, count: Int)
+
+final case class IntervalAndDegrees(interval: Interval, degree: Int)
+
+
+sealed abstract class Action
+
+object Action {
+  final case object CREATE extends Action
+
+  final case object UPDATE extends Action
+
+  final case object DELETE extends Action
+}
+
+sealed abstract class Entity
+
+object Entity {
+  final case class VERTEX(objId: Long) extends Entity
+
+  final case class EDGE(id: Long, srcId: Long, dstId: Long) extends Entity
+}
+
+/** LogTSV
+ *
+ * Everything is built around this case class
+ *
+ * @param timestamp  When did the log_entry happen?
+ * @param action     Type of action
+ * @param entity     The type of the object with id(s)
+ * @param attributes List of (Key,Value) attributes relevant to the entry
+ */
+case class LogTSV(
+                   timestamp: Instant,
+                   action: Action,
+                   entity: Entity,
+                   attributes: Attributes
+                 )

--- a/data-generation/src/main/scala/thesis/Landy.scala
+++ b/data-generation/src/main/scala/thesis/Landy.scala
@@ -1,15 +1,16 @@
 package thesis
 
-import org.apache.spark.graphx.{Edge, EdgeRDD, EdgeTriplet, Graph, VertexRDD}
+import org.apache.spark.graphx._
 import org.apache.spark.rdd.RDD
-import thesis.LTSV.Attributes
+import thesis.LTSV.{Attributes, EdgeId}
 import thesis.SnapshotDeltaObject.LandyAttributeGraph
 
 import java.time.Instant
 import scala.math.Ordered.orderingToOrdered
 
-case class LandyVertexPayload(id: Long, validFrom: Instant, validTo:Instant, attributes:Attributes)
-case class LandyEdgePayload(id: Long, validFrom: Instant, validTo:Instant, attributes:Attributes)
+case class LandyVertexPayload(id: Long, validFrom: Instant, validTo: Instant, attributes: Attributes)
+
+case class LandyEdgePayload(id: Long, validFrom: Instant, validTo: Instant, attributes: Attributes)
 
 
 class Landy(val graph: LandyAttributeGraph) extends TemporalGraph[LandyVertexPayload, LandyEdgePayload] {
@@ -22,15 +23,20 @@ class Landy(val graph: LandyAttributeGraph) extends TemporalGraph[LandyVertexPay
     val notNullVertices = this.vertices.filter(vertex => vertex._2 != null) // Required since the vertex payload is null when "floating edges" are created
     val vertices = notNullVertices.filter(vertex =>
       vertex._2.validFrom < instant &&
-      vertex._2.validTo >= instant
+        vertex._2.validTo >= instant
     ).map(vertex => (vertex._2.id, vertex._2))
 
     val edges = this.edges.filter(edge =>
-        edge.attr.validFrom < instant &&
+      edge.attr.validFrom < instant &&
         edge.attr.validTo >= instant
-      )
+    )
     Graph(vertices, edges)
   }
+
+  /** Return the ids of entities activated or created in the interval
+   *
+   * @param interval Inclusive interval
+   * @return Tuple with the activated entities
+   */
+  override def activatedEntities(interval: Interval): (RDD[VertexId], RDD[EdgeId]) = throw new NotImplementedError()
 }
-
-

--- a/data-generation/src/main/scala/thesis/Landy.scala
+++ b/data-generation/src/main/scala/thesis/Landy.scala
@@ -2,15 +2,10 @@ package thesis
 
 import org.apache.spark.graphx._
 import org.apache.spark.rdd.RDD
-import thesis.LTSV.{Attributes, EdgeId}
-import thesis.SnapshotDeltaObject.LandyAttributeGraph
+import thesis.DataTypes.{EdgeId, LandyAttributeGraph}
 
 import java.time.Instant
 import scala.math.Ordered.orderingToOrdered
-
-case class LandyVertexPayload(id: Long, validFrom: Instant, validTo: Instant, attributes: Attributes)
-
-case class LandyEdgePayload(id: Long, validFrom: Instant, validTo: Instant, attributes: Attributes)
 
 
 class Landy(val graph: LandyAttributeGraph) extends TemporalGraph[LandyVertexPayload, LandyEdgePayload] {

--- a/data-generation/src/main/scala/thesis/LogTSV.scala
+++ b/data-generation/src/main/scala/thesis/LogTSV.scala
@@ -2,51 +2,13 @@ package thesis
 
 import org.apache.spark.rdd.RDD
 import thesis.Action.{CREATE, DELETE, UPDATE}
+import thesis.DataTypes.Attributes
 import thesis.Entity.{EDGE, VERTEX}
-import thesis.LTSV.Attributes
 
 import java.time.{Instant, LocalDateTime, ZoneOffset}
 import scala.collection.immutable
 import scala.io.Source
 import scala.util.Try
-
-/** Action Enum
- *
- */
-sealed abstract class Action
-
-object Action {
-  final case object CREATE extends Action
-
-  final case object UPDATE extends Action
-
-  final case object DELETE extends Action
-}
-
-sealed abstract class Entity
-
-object Entity {
-  final case class VERTEX(objId: Long) extends Entity
-
-  final case class EDGE(id: Long, srcId: Long, dstId: Long) extends Entity
-}
-
-/** LogTSV
- *
- * Everything is built around this case class
- *
- * @param timestamp  When did the log_entry happen?
- * @param action     Type of action
- * @param entity     The type of the object with id(s)
- * @param attributes List of (Key,Value) attributes relevant to the entry
- */
-case class LogTSV(
-                   timestamp: Instant,
-                   action: Action,
-                   entity: Entity,
-                   attributes: Attributes
-                 )
-
 
 object LTSV {
   def stringToEntity(s: String): Option[Entity] = {
@@ -57,10 +19,6 @@ object LTSV {
     }
   }
 
-  // Type alias
-  type Attributes = immutable.HashMap[String, String]
-  // Like VertexId but for Edges since we are in dire need of a surrogate
-  type EdgeId = Long
 
   /** Serialize a single LogTSV
    *

--- a/data-generation/src/main/scala/thesis/SnapshotDelta.scala
+++ b/data-generation/src/main/scala/thesis/SnapshotDelta.scala
@@ -17,15 +17,26 @@ import scala.util.Try
 
 
 //Should just be a trait
+// TODO refactor this into its own file, snapshotDelta is a very big file ATM
 abstract class TemporalGraph[VD: ClassTag, ED: ClassTag] extends Serializable {
   val vertices: VertexRDD[VD]
   val edges: EdgeRDD[ED]
   val triplets: RDD[EdgeTriplet[VD, ED]]
 
   def snapshotAtTime(instant: Instant): Graph[VD, ED]
+
+  /** Return the ids of entities activated or created in the interval
+   *
+   * @param interval Inclusive interval
+   * @return Tuple with the activated entities
+   */
+  def activatedEntities(interval: Interval): (RDD[VertexId], RDD[EdgeId])
 }
 
 case class SnapshotEdgePayload(id: EdgeId, attributes: Attributes)
+
+//TODO have file with all the finurlige case classes
+case class Interval(start: Instant, stop: Instant)
 
 class SnapshotDelta(val graphs: MutableList[Snapshot],
                     val logs: RDD[LogTSV],
@@ -42,71 +53,44 @@ class SnapshotDelta(val graphs: MutableList[Snapshot],
     )
   }
 
-  def backwardsApplyLogs(g: AttributeGraph, logsToApply: RDD[LogTSV]): AttributeGraph = throw new NotImplementedError()
-
-  override def snapshotAtTime(instant: Instant): AttributeGraph = {
-
-    //Closest graph should be based on number of logs, not time.
-    // But for it to be feasible each graph should have a sequence ID as well
-    // This is possible, I think, but not implemented
-    val closestGraph = graphs.reduceLeft((snap1, snap2) =>
-      if (snap2.instant > instant) { 
+  def getClosestGraph(graphs: Seq[Snapshot], instant: Instant): Snapshot =
+    graphs.reduceLeft((snap1, snap2) =>
+      if (snap2.instant > instant) {
         snap1
       } else {
         snap2
       })
+
+  /** Return the ids of entities activated or created in the interval
+   *
+   * @param interval Inclusive interval
+   * @return Tuple with the activated entities
+   */
+  override def activatedEntities(interval: Interval): (RDD[VertexId], RDD[EdgeId]) = {
+    val relevantLogs = getLogsInInterval(logs, interval)
+    val (vertexSquash, edgeSquash) = getSquashedActionsByEntityId(relevantLogs)
+    val activatedVertices = vertexSquash.filter(_._2.action == CREATE).map(_._1)
+    val activatedEdges = edgeSquash.filter(_._2.action == CREATE).map(_._1)
+    (activatedVertices, activatedEdges)
+  }
+
+  override def snapshotAtTime(instant: Instant): AttributeGraph = {
+
+    val closestGraph = getClosestGraph(graphs, instant)
     logger.warn(s"Instant $instant, Closest :graph${closestGraph.instant}")
     if (closestGraph.instant == instant) {
       logger.warn("The queried graph is already materialized")
       closestGraph.graph
-    } else if (instant < closestGraph.instant) { // We are asking an instant before the initial materialized snapshot
+    } else if (instant < closestGraph.instant) {
       logger.warn("Closest graph in the future, and there is no one in the past.")
-      createGraph(logs.map(l => (l.timestamp, l)).filterByRange(Instant.MIN, instant).map(_._2))
+      val initialLogs = getLogsInInterval(logs, Interval(Instant.MIN, instant))
+      createGraph(initialLogs)
     } else {
       logger.warn("Closest graph is in the past. Need to apply logs forwards")
-      val logsToApply = logs.map(l => (l.timestamp, l)).filterByRange(closestGraph.instant, instant).map(_._2)
+      val logsToApply = getLogsInInterval(logs, Interval(closestGraph.instant, instant))
       forwardApplyLogs(closestGraph.graph, logsToApply)
     }
   }
-
-
-  /*
-    override def persist(newLevel: StorageLevel): Graph[VD, ED] = graph.persist(newLevel)
-
-    override def cache(): Graph[VD, ED] = graph.cache
-
-    override def checkpoint(): Unit = graph.checkpoint
-
-    override def isCheckpointed: Boolean = graph.isCheckpointed
-
-    override def getCheckpointFiles: Seq[String] = graph.getCheckpointFiles
-
-    override def unpersist(blocking: Boolean): Graph[VD, ED] = graph.unpersist(blocking)
-
-    override def unpersistVertices(blocking: Boolean): Graph[VD, ED] = graph.unpersistVertices(blocking)
-
-    override def partitionBy(partitionStrategy: PartitionStrategy): Graph[VD, ED] = graph.partitionBy(partitionStrategy)
-
-    override def partitionBy(partitionStrategy: PartitionStrategy, numPartitions: PartitionID): Graph[VD, ED] = graph.partitionBy(partitionStrategy, numPartitions)
-
-    override def mapVertices[VD2](map: (VertexId, VD) => VD2)(implicit evidence$3: ClassTag[VD2], eq: VD =:= VD2): Graph[VD2, ED] = graph.mapVertices(map)(evidence$3, eq)
-
-    override def mapEdges[ED2](map: (PartitionID, Iterator[Edge[ED]]) => Iterator[ED2])(implicit evidence$5: ClassTag[ED2]): Graph[VD, ED2] = graph.mapEdges(map)(evidence$5)
-
-    override def mapTriplets[ED2](map: (PartitionID, Iterator[EdgeTriplet[VD, ED]]) => Iterator[ED2], tripletFields: TripletFields)(implicit evidence$8: ClassTag[ED2]): Graph[VD, ED2] =
-      graph.mapTriplets(map, tripletFields)(evidence$8)
-
-    override def reverse: Graph[VD, ED] = graph.reverse
-
-    override def subgraph(epred: EdgeTriplet[VD, ED] => Boolean, vpred: (VertexId, VD) => Boolean): Graph[VD, ED] = graph.subgraph(epred, vpred)
-
-    override def mask[VD2, ED2](other: Graph[VD2, ED2])(implicit evidence$9: ClassTag[VD2], evidence$10: ClassTag[ED2]): Graph[VD, ED] = graph.mask(other)(evidence$9, evidence$10)
-
-    override def groupEdges(merge: (ED, ED) => ED): Graph[VD, ED] = graph.groupEdges(merge)
-
-    override def outerJoinVertices[U, VD2](other: RDD[(VertexId, U)])(mapFunc: (VertexId, VD, Option[U]) => VD2)(implicit evidence$13: ClassTag[U], evidence$14: ClassTag[VD2], eq: VD =:= VD2): Graph[VD2, ED] =
-      graph.outerJoinVertices(other)(mapFunc)(evidence$13, evidence$14, eq)
-   */
 }
 
 
@@ -183,8 +167,21 @@ object SnapshotDeltaObject {
           .copy(attributes = rightWayMergeHashMap(edge.attr.attributes, log.attributes)))
   }
 
+  /** Retrieve logs in the inclusive interval
+   *
+   * @param logs
+   * @param interval
+   * @return
+   */
+  def getLogsInInterval(logs: RDD[LogTSV], interval: Interval): RDD[LogTSV] = {
+    logs
+      .map(log => (log.timestamp, log))
+      .filterByRange(interval.start, interval.stop)
+      .map(_._2)
+  }
+
   def applyEdgeLogsToSnapshot(snapshot: AttributeGraph, logs: RDD[LogTSV]): RDD[Edge[SnapshotEdgePayload]] = {
-    val uuid = java.util.UUID.randomUUID.toString.take(5)
+    val uuid = java.util.UUID.randomUUID.toString.take(5) // For debugging purposes
     val previousSnapshotEdgesKV = snapshot.edges.map(edge => (edge.attr.id, edge))
 
     val squashedEdgeActions = getSquashedActionsByEdgeId(logs)
@@ -216,7 +213,7 @@ object SnapshotDeltaObject {
 
   def logToEdge(log: LogTSV): Edge[SnapshotEdgePayload] = {
     log.entity match {
-      case VERTEX(objId) => throw new IllegalStateException("This does not make sense. Only edges allowed")
+      case _: VERTEX => throw new IllegalStateException("This does not make sense. Only edges allowed")
       case EDGE(id, srcId, dstId) => Edge(srcId, dstId, SnapshotEdgePayload(id, log.attributes))
     }
   }
@@ -229,12 +226,13 @@ object SnapshotDeltaObject {
     })
 
     // Group by edge id and merge
-    edgeIdWithEdgeActions.groupByKey()
+    edgeIdWithEdgeActions
+      .groupByKey()
       .map(edgeWithActions => (edgeWithActions._1, mergeLogTSVs(edgeWithActions._2)))
   }
 
   def applyVertexLogsToSnapshot(snapshot: AttributeGraph, logs: RDD[LogTSV]): RDD[(VertexId, Attributes)] = {
-    val uuid = java.util.UUID.randomUUID.toString.take(5)
+    val uuid = java.util.UUID.randomUUID.toString.take(5) // For debug purposes
     val previousSnapshotVertices = snapshot.vertices
 
     val vertexIDsWithAction: RDD[(Long, LogTSV)] = getSquashedActionsByVertexId(logs)
@@ -274,6 +272,8 @@ object SnapshotDeltaObject {
     vertexIdWithVertexActions.groupByKey()
       .map(vertexWithActions => (vertexWithActions._1, mergeLogTSVs(vertexWithActions._2)))
   }
+
+  def getSquashedActionsByEntityId(logs: RDD[LogTSV]): (RDD[(VertexId, LogTSV)], RDD[(EdgeId, LogTSV)]) = (getSquashedActionsByVertexId(logs), getSquashedActionsByEdgeId(logs))
 
   def mergeLogTSVs(logs: Iterable[LogTSV]): LogTSV = logs.reduce(mergeLogTSV)
 

--- a/data-generation/src/main/scala/thesis/TemporalGraph.scala
+++ b/data-generation/src/main/scala/thesis/TemporalGraph.scala
@@ -1,0 +1,23 @@
+package thesis
+
+import org.apache.spark.graphx.{EdgeRDD, EdgeTriplet, Graph, VertexId, VertexRDD}
+import org.apache.spark.rdd.RDD
+import thesis.DataTypes.EdgeId
+
+import java.time.Instant
+import scala.reflect.ClassTag
+
+abstract class TemporalGraph[VD: ClassTag, ED: ClassTag] extends Serializable {
+  val vertices: VertexRDD[VD]
+  val edges: EdgeRDD[ED]
+  val triplets: RDD[EdgeTriplet[VD, ED]]
+
+  def snapshotAtTime(instant: Instant): Graph[VD, ED]
+
+  /** Return the ids of entities activated or created in the interval
+   *
+   * @param interval Inclusive interval
+   * @return Tuple with the activated entities
+   */
+  def activatedEntities(interval: Interval): (RDD[VertexId], RDD[EdgeId])
+}

--- a/data-generation/src/main/scala/thesis/TopologyGraphGenerator.scala
+++ b/data-generation/src/main/scala/thesis/TopologyGraphGenerator.scala
@@ -9,16 +9,6 @@ import org.slf4j.LoggerFactory
 
 import java.time.Instant
 
-final case class TimeInterval(start: Instant, stop: Instant)
-
-sealed abstract class DataSource
-
-object DataSource {
-  final case object Reptilian extends DataSource
-
-  final case object FbMessages extends DataSource
-
-}
 
 object TopologyGraphGenerator {
 
@@ -34,7 +24,7 @@ object TopologyGraphGenerator {
   def generateGraph(
                      threshold: BigDecimal,
                      dataSource: DataSource = DataSource.Reptilian
-                   )(implicit spark: SparkSession): Graph[Long, TimeInterval] = {
+                   )(implicit spark: SparkSession): Graph[Long, Interval] = {
     val (filePath, delimiter) = getPathAndDelim(dataSource)
 
     val logger = LoggerFactory.getLogger("TopologyGraphGenerator")
@@ -56,12 +46,12 @@ object TopologyGraphGenerator {
       .rdd.map(row => row.getAs[String]("from").toLong)
       .map(long => (long, long))
 
-    val edges: RDD[Edge[TimeInterval]] = leadDf
+    val edges: RDD[Edge[Interval]] = leadDf
       .select("from", "to", "from time", "to time")
       .rdd.map(
       row => {
         Edge(row.getAs[String]("from").toLong, row.getAs[String]("to").toLong,
-          TimeInterval(Instant.ofEpochSecond(row.getAs[String]("from time").toLong), Instant.ofEpochSecond(row.getAs[String]("to time").toLong)))
+          Interval(Instant.ofEpochSecond(row.getAs[String]("from time").toLong), Instant.ofEpochSecond(row.getAs[String]("to time").toLong)))
       }
     )
 

--- a/data-generation/src/test/scala/SnapshotDeltaSpec.scala
+++ b/data-generation/src/test/scala/SnapshotDeltaSpec.scala
@@ -144,7 +144,7 @@ class SnapshotDeltaSpec extends AnyFlatSpec with SparkTestWrapper {
   }
 
   // backwardsApply is not implemented
-  ignore should "return correct graph given a timestamp close to a snapshot in the future" in {
+  it should "return correct graph given a timestamp close to a snapshot in the future" in {
     implicit val sparkContext: SparkContext = spark.sparkContext
 
     val updates = List(1, 1, 1, 1, 1, 1, 1) // List of amount of updates for t_1, t_2 .. t_6
@@ -154,6 +154,7 @@ class SnapshotDeltaSpec extends AnyFlatSpec with SparkTestWrapper {
     assertGraphSimilarity(snapshot, createGraph(logs.take(2))) // Take(2) == Instant.ofEpoch(1)
   }
 
+  // This test currently tests an unused function
   "returnClosestGraph" should "return the closet graph given an two graphs and an instant" in {
     implicit val sparkContext: SparkContext = spark.sparkContext
 


### PR DESCRIPTION
Currenlty a timebased heurestic for finding the least expensive
operations, but it should be number-of-operations in the future

La også til en metode for activatedEntities som vi har sagt vi skal implmentere I overLeaf

Edit: Denne PRen ble helt utrolig kaotisk, beklager det. Rydder den opp på mandag. Men ser gjerne etter tilbakemelding på commitsene