### PR TITLE
fix: deterministic timestamps

### DIFF
--- a/data-generation/src/main/scala/factories/LogFactory.scala
+++ b/data-generation/src/main/scala/factories/LogFactory.scala
@@ -30,7 +30,7 @@ case class LogFactory(
   }
 
   def buildSingleSequence(entity: Entity, updateAmount: Int = 5): Seq[LogTSV] = {
-    val timestamps = TimeUtils.getRandomOrderedTimestamps(updateAmount, startTime, endTime)
+    val timestamps = TimeUtils.getDeterministicOrderedTimestamps(updateAmount, startTime, endTime)
     val create = Seq(LogTSV(
       timestamp = timestamps.head,
       action = CREATE,

--- a/data-generation/src/main/scala/utils/TimeUtils.scala
+++ b/data-generation/src/main/scala/utils/TimeUtils.scala
@@ -14,7 +14,6 @@ object TimeUtils {
   }
 
   def getDeterministicOrderedTimestamps(amount: Int, startTime: Instant, endTime: Instant): Seq[Instant] = {
-    // 5: 1->5 = [1,2,3,4,5]
     if (amount == 1) {
       return Seq(startTime)
     }

--- a/data-generation/src/main/scala/utils/TimeUtils.scala
+++ b/data-generation/src/main/scala/utils/TimeUtils.scala
@@ -13,6 +13,19 @@ object TimeUtils {
       .map(timestamp => Instant.ofEpochSecond(timestamp.toLong))
   }
 
+  def getDeterministicOrderedTimestamps(amount: Int, startTime: Instant, endTime: Instant): Seq[Instant] = {
+    // 5: 1->5 = [1,2,3,4,5]
+    if (amount == 1) {
+      return Seq(startTime)
+    }
+    val step = (endTime.getEpochSecond - startTime.getEpochSecond) / (amount - 1)
+    var timestamps = Seq[Instant]()
+    for (i <- 0 until amount) {
+      timestamps = timestamps :+ Instant.ofEpochSecond(startTime.getEpochSecond + i * step)
+    }
+    timestamps
+  }
+
   /** Convert Long to Instant
    *
    * If this function is in scope, everytime someone uses Long for a function that

--- a/data-generation/src/test/scala/utils/TimeUtilsSpec.scala
+++ b/data-generation/src/test/scala/utils/TimeUtilsSpec.scala
@@ -6,7 +6,7 @@ import java.time.Instant
 
 class TimeUtilsSpec extends AnyFlatSpec {
   val start: Instant = Instant.parse("2000-01-01T00:00:00.000Z")
-  val end: Instant = Instant.parse("2001-01-01T00:00:00.000Z")
+  val end: Instant = Instant.parse("2000-01-01T00:04:00.000Z")
   val timestamps: Seq[Instant] = TimeUtils.getRandomOrderedTimestamps(amount = 3, startTime = start, endTime = end)
 
   behavior of "TimeUtils"
@@ -22,6 +22,20 @@ class TimeUtilsSpec extends AnyFlatSpec {
   }
 
   it should "return the requested amount of timestamps" in {
-  assert(timestamps.length == 3)
+    assert(timestamps.length == 3)
+  }
+
+  it should "be able to get deterministic timestamps" in {
+    val deterministicTimestamps = TimeUtils.getDeterministicOrderedTimestamps(amount = 5, startTime = start, endTime = end)
+    val expectedTimestamps = Seq(
+      start,
+      Instant.parse("2000-01-01T00:01:00.000Z"),
+      Instant.parse("2000-01-01T00:02:00.000Z"),
+      Instant.parse("2000-01-01T00:03:00.000Z"),
+      end
+    )
+
+    assert(deterministicTimestamps.length == 5)
+    assert(deterministicTimestamps.equals(expectedTimestamps))
   }
 }


### PR DESCRIPTION
Legger til utility-funksjon i TimeUtils som lager deterministiske tidsstempler. 
E.g. start=1, end=5 , amount=5 => [1, 2, 3, 4, 5]. Tidene blir altså fordelt uniformt utover. Dette er forskjellig fra den forrige utility-funksjonen som gir forskjellig hver gang, så med samme betingelser _kunne_ man fått [5, 5, 5, 5, 5]