### PR TITLE
feat: landy activated entities

### DIFF
--- a/data-generation/src/main/scala/factories/LandyGraphFactory.scala
+++ b/data-generation/src/main/scala/factories/LandyGraphFactory.scala
@@ -4,7 +4,7 @@ import org.apache.spark.graphx.{Edge, Graph, VertexId}
 import org.apache.spark.sql.SparkSession
 import thesis.DataTypes.LandyAttributeGraph
 import thesis.SparkConfiguration.getSparkSession
-import thesis.{LandyEdgePayload, LandyVertexPayload}
+import thesis.LandyEntityPayload
 
 import java.time.Instant
 import scala.collection.immutable.HashMap
@@ -23,10 +23,10 @@ object LandyGraphFactory {
   val t2 = Instant.parse("2001-01-01T00:00:00.000Z")
   val t3 = Instant.parse("2002-01-01T00:00:00.000Z")
 
-  def getVertices(): Seq[(VertexId, LandyVertexPayload)] = {
+  def getVertices(): Seq[(VertexId, LandyEntityPayload)] = {
     Seq(
       (1000L,
-        LandyVertexPayload(
+        LandyEntityPayload(
           id = 1L,
           validFrom = t1,
           validTo = t2,
@@ -36,7 +36,7 @@ object LandyGraphFactory {
         )
       ),
       (1001L,
-        LandyVertexPayload(
+        LandyEntityPayload(
           id = 1L,
           validFrom = t2,
           validTo = t3,
@@ -46,7 +46,7 @@ object LandyGraphFactory {
         )
       ),
       (1002L,
-        LandyVertexPayload(
+        LandyEntityPayload(
           id = 2L,
           validFrom = t1,
           validTo = t3,
@@ -58,10 +58,10 @@ object LandyGraphFactory {
     )
   }
 
-  def getEdges(): Seq[Edge[LandyEdgePayload]] = {
+  def getEdges(): Seq[Edge[LandyEntityPayload]] = {
     Seq(
       Edge(1L, 2L,
-        LandyEdgePayload(
+        LandyEntityPayload(
           id = 1003L,
           validFrom = t1,
           validTo = t2,
@@ -71,7 +71,7 @@ object LandyGraphFactory {
         )
       ),
       Edge(1L, 2L,
-        LandyEdgePayload(
+        LandyEntityPayload(
           id = 1004L,
           validFrom = t2,
           validTo = t3,

--- a/data-generation/src/main/scala/thesis/DataTypes.scala
+++ b/data-generation/src/main/scala/thesis/DataTypes.scala
@@ -7,13 +7,9 @@ import java.time.Instant
 import scala.collection.immutable
 
 object DataTypes {
-  //SnapshotDeltaGraph
   type AttributeGraph = Graph[Attributes, SnapshotEdgePayload]
-  //LandyGraph
-  type LandyAttributeGraph = Graph[LandyVertexPayload, LandyEdgePayload]
-  // Type alias
+  type LandyAttributeGraph = Graph[LandyEntityPayload, LandyEntityPayload]
   type Attributes = immutable.HashMap[String, String]
-  // Like VertexId but for Edges since we are in dire need of a surrogate
   type EdgeId = Long
 }
 
@@ -32,9 +28,7 @@ object SnapshotIntervalType {
 
 final case class Snapshot(graph: AttributeGraph, instant: Instant)
 
-case class LandyVertexPayload(id: Long, validFrom: Instant, validTo: Instant, attributes: Attributes)
-
-case class LandyEdgePayload(id: Long, validFrom: Instant, validTo: Instant, attributes: Attributes)
+case class LandyEntityPayload(id: Long, validFrom: Instant, validTo: Instant, attributes: Attributes)
 
 sealed abstract class DataSource
 

--- a/data-generation/src/main/scala/thesis/Landy.scala
+++ b/data-generation/src/main/scala/thesis/Landy.scala
@@ -38,9 +38,7 @@ class Landy(graph: LandyAttributeGraph) extends TemporalGraph[LandyEntityPayload
       .groupByKey() // Group all
       .map(vertex => (vertex._1, getEarliest(vertex._2.toSeq))) // Get first local vertex
 
-    firstLocalVertices.filter(vertex =>
-      vertex._2.validFrom >= interval.start &&
-        vertex._2.validFrom <= interval.stop)
+    firstLocalVertices.filter(vertex => isInstantInInterval(vertex._2.validFrom, interval))
       .map(vertex => vertex._2.id)
   }
 
@@ -49,10 +47,8 @@ class Landy(graph: LandyAttributeGraph) extends TemporalGraph[LandyEntityPayload
       .map(edge => (edge.attr.id, edge.attr))
       .groupByKey()
       .map(edge => (edge._1, getEarliest(edge._2.toSeq)))
-      .filter(edge =>
-        edge._2.validFrom >= interval.start &&
-          edge._2.validFrom <= interval.stop
-      ).map(edge => edge._1)
+      .filter(edge => isInstantInInterval(edge._2.validFrom, interval))
+      .map(edge => edge._1)
   }
 
   /**
@@ -72,6 +68,10 @@ class Landy(graph: LandyAttributeGraph) extends TemporalGraph[LandyEntityPayload
    */
   private def localVertices: VertexRDD[LandyEntityPayload] = {
     this.vertices.filter(vertex => vertex._2 != null)
+  }
+
+  private def isInstantInInterval(instant: Instant, interval: Interval): Boolean = {
+    instant >= interval.start && instant <= interval.stop
   }
 }
 

--- a/data-generation/src/main/scala/thesis/Landy.scala
+++ b/data-generation/src/main/scala/thesis/Landy.scala
@@ -12,17 +12,18 @@ import scala.collection.mutable
 import scala.math.Ordered.orderingToOrdered
 
 
-class Landy(graph: LandyAttributeGraph) extends TemporalGraph[LandyVertexPayload, LandyEdgePayload] {
-  override val vertices: VertexRDD[LandyVertexPayload] = graph.vertices
-  override val edges: EdgeRDD[LandyEdgePayload] = graph.edges
-  override val triplets: RDD[EdgeTriplet[LandyVertexPayload, LandyEdgePayload]] = graph.triplets
+class Landy(graph: LandyAttributeGraph) extends TemporalGraph[LandyEntityPayload, LandyEntityPayload] {
+  override val vertices: VertexRDD[LandyEntityPayload] = graph.vertices
+  override val edges: EdgeRDD[LandyEntityPayload] = graph.edges
+  override val triplets: RDD[EdgeTriplet[LandyEntityPayload, LandyEntityPayload]] = graph.triplets
 
-  override def snapshotAtTime(instant: Instant): Graph[LandyVertexPayload, LandyEdgePayload] = {
-    val notNullVertices = this.vertices.filter(vertex => vertex._2 != null) // Required since the vertex payload is null when "floating edges" are created
-    val vertices = notNullVertices.filter(vertex =>
-      vertex._2.validFrom < instant &&
-        vertex._2.validTo >= instant
-    ).map(vertex => (vertex._2.id, vertex._2))
+  override def snapshotAtTime(instant: Instant): Graph[LandyEntityPayload, LandyEntityPayload] = {
+    val vertices = localVertices
+      .filter(vertex =>
+        vertex._2.validFrom < instant &&
+          vertex._2.validTo >= instant
+      )
+      .map(vertex => (vertex._2.id, vertex._2))
 
     val edges = this.edges.filter(edge =>
       edge.attr.validFrom < instant &&
@@ -31,38 +32,75 @@ class Landy(graph: LandyAttributeGraph) extends TemporalGraph[LandyVertexPayload
     Graph(vertices, edges)
   }
 
-  override def activatedVertices(interval: Interval): RDD[VertexId] = throw new NotImplementedError()
+  override def activatedVertices(interval: Interval): RDD[VertexId] = {
+    val firstLocalVertices = localVertices // Remove global vertices
+      .map(vertex => (vertex._2.id, vertex._2)) // Get the global vertex ID
+      .groupByKey() // Group all
+      .map(vertex => (vertex._1, getEarliest(vertex._2.toSeq))) // Get first local vertex
 
-  override def activatedEdges(interval: Interval): RDD[EdgeId] = throw new NotImplementedError()
+    firstLocalVertices.filter(vertex =>
+      vertex._2.validFrom >= interval.start &&
+        vertex._2.validFrom <= interval.stop)
+      .map(vertex => vertex._2.id)
+  }
 
+  override def activatedEdges(interval: Interval): RDD[EdgeId] = {
+    this.edges
+      .map(edge => (edge.attr.id, edge.attr))
+      .groupByKey()
+      .map(edge => (edge._1, getEarliest(edge._2.toSeq)))
+      .filter(edge =>
+        edge._2.validFrom >= interval.start &&
+          edge._2.validFrom <= interval.stop
+      ).map(edge => edge._1)
+  }
+
+  /**
+   * @param payloads Payload updates for a single entity
+   * @return The data that corresponds to the earliest timestamp
+   */
+  private def getEarliest(payloads: Seq[LandyEntityPayload]): LandyEntityPayload = {
+    payloads.minBy(_.validFrom)
+  }
+
+  /**
+   * Get the local vertices, i.e. those who have a payload.
+   * Global vertices, which have no payload, are created when edges connect
+   * vertices that don't exist from before.
+   *
+   * @return The local vertices of the graph
+   */
+  private def localVertices: VertexRDD[LandyEntityPayload] = {
+    this.vertices.filter(vertex => vertex._2 != null)
+  }
 }
 
 object Landy {
-  def createEdge(log: LogTSV, validTo: Instant): Edge[LandyEdgePayload] = {
+  def createEdge(log: LogTSV, validTo: Instant): Edge[LandyEntityPayload] = {
     log.entity match {
       case Entity.VERTEX(_) => throw new IllegalStateException("This should not be called on a log with vertices")
       case Entity.EDGE(id, srcId, dstId) => {
-        val payload = LandyEdgePayload(id = id, validFrom = log.timestamp, validTo = validTo, attributes = log.attributes)
+        val payload = LandyEntityPayload(id = id, validFrom = log.timestamp, validTo = validTo, attributes = log.attributes)
         Edge(srcId, dstId, payload)
       }
     }
   }
 
-  def createVertex(log: LogTSV, validTo: Instant): (VertexId, LandyVertexPayload) = {
+  def createVertex(log: LogTSV, validTo: Instant): (VertexId, LandyEntityPayload) = {
     log.entity match {
       case Entity.VERTEX(objId) => {
-        val payload = LandyVertexPayload(id = objId, validFrom = log.timestamp, validTo = validTo, attributes = log.attributes)
+        val payload = LandyEntityPayload(id = objId, validFrom = log.timestamp, validTo = validTo, attributes = log.attributes)
         (UtilsUtils.uuid, payload)
       }
       case Entity.EDGE(_, _, _) => throw new IllegalStateException("This should not be called on a log with edges")
     }
   }
 
-  def generateEdges(logs: Seq[LogTSV]): Seq[Edge[LandyEdgePayload]] = {
+  def generateEdges(logs: Seq[LogTSV]): Seq[Edge[LandyEntityPayload]] = {
     val reversedLogs = LogUtils.reverse(logs)
     val aVeryBigDate = Instant.MAX
     var lastTimestamp = aVeryBigDate
-    val edges = mutable.MutableList[Edge[LandyEdgePayload]]()
+    val edges = mutable.MutableList[Edge[LandyEntityPayload]]()
     for (log <- reversedLogs) {
       // DELETES should not create an edge, but instead record the deletion timestamp to be used later.
       if (log.action == CREATE || log.action == UPDATE) {
@@ -73,11 +111,11 @@ object Landy {
     edges
   }
 
-  def generateVertices(logs: Seq[LogTSV]): Seq[(VertexId, LandyVertexPayload)] = {
+  def generateVertices(logs: Seq[LogTSV]): Seq[(VertexId, LandyEntityPayload)] = {
     val reversedLogs = LogUtils.reverse(logs)
     val aVeryBigDate = Instant.MAX
     var lastTimestamp = aVeryBigDate
-    val vertices = mutable.MutableList[(VertexId, LandyVertexPayload)]()
+    val vertices = mutable.MutableList[(VertexId, LandyEntityPayload)]()
     for (log <- reversedLogs) {
       // DELETES should not create a vertex, but instead record the deletion timestamp to be used later.
       if (log.action == CREATE || log.action == UPDATE) {

--- a/data-generation/src/main/scala/utils/TimeUtils.scala
+++ b/data-generation/src/main/scala/utils/TimeUtils.scala
@@ -13,6 +13,15 @@ object TimeUtils {
       .map(timestamp => Instant.ofEpochSecond(timestamp.toLong))
   }
 
+  /**
+   * Get evenly distributed timestamps.
+   * E.g. amount=5, startTime=1, endTime=5 returns [1, 2, 3, 4, 5]
+   *
+   * @param amount    The number of timestamps wanted
+   * @param startTime The first timestamp in the returned value
+   * @param endTime   The last timestamp in the returned value
+   * @return
+   */
   def getDeterministicOrderedTimestamps(amount: Int, startTime: Instant, endTime: Instant): Seq[Instant] = {
     if (amount == 1) {
       return Seq(startTime)

--- a/data-generation/src/test/scala/LandySpec.scala
+++ b/data-generation/src/test/scala/LandySpec.scala
@@ -1,8 +1,15 @@
 import factories.LandyGraphFactory
 import factories.LandyGraphFactory.createGraph
-import thesis.Landy
+import thesis.{Interval, Landy}
 import org.scalatest.flatspec.AnyFlatSpec
 import wrappers.SparkTestWrapper
+import factories.LogFactory
+import org.apache.spark.SparkContext
+import thesis.Entity.{EDGE, VERTEX}
+import utils.TimeUtils
+import utils.TimeUtils._
+
+import java.time.Instant
 
 
 class LandySpec extends AnyFlatSpec with SparkTestWrapper {
@@ -21,5 +28,37 @@ class LandySpec extends AnyFlatSpec with SparkTestWrapper {
 
     assert(graph.vertices.count() == 2)
     assert(graph.edges.count() == 1)
+  }
+
+  it can "query activated edges" in {
+    implicit val sparkContext: SparkContext = spark.sparkContext
+    val start = Instant.parse("2000-01-01T00:00:00Z")
+    val end = Instant.parse("2000-01-01T10:00:00Z")
+    val timestamps = TimeUtils.getDeterministicOrderedTimestamps(amount = 11, startTime = start, endTime = end)
+
+    val vertexLogs1 = LogFactory(startTime = timestamps(2), endTime = timestamps(8)).buildSingleSequence(VERTEX(1))
+    val vertexLogs2 = LogFactory(startTime = timestamps(5), endTime = timestamps(10)).buildSingleSequence(VERTEX(2))
+    val edgeLogs = LogFactory(startTime = timestamps(4), endTime = timestamps(8)).buildSingleSequence(EDGE(1, 1, 2))
+    val logs = (vertexLogs1 ++ vertexLogs2 ++ edgeLogs).sortBy(_.timestamp)
+    val logRDD = sparkContext.parallelize(logs)
+    val g = Landy(logRDD)
+
+    val intervalWithVertex1 = g.activatedEntities(Interval(timestamps.head, timestamps(3)))
+    val intervalWithVertex2 = g.activatedEntities(Interval(timestamps(5), timestamps(7)))
+    val intervalWithEdge = g.activatedEntities(Interval(timestamps(3), timestamps(5)))
+    val intervalWithV1andEdge = g.activatedEntities(Interval(timestamps.head, timestamps(4)))
+    val intervalWithV2andEdge = g.activatedEntities(Interval(timestamps(4), timestamps(7)))
+    val intervalWithAll = g.activatedEntities(Interval(timestamps.head, timestamps(10)))
+
+
+    assert(intervalWithVertex1._2.isEmpty() && intervalWithVertex1._1.count() == 1)
+
+    assert(intervalWithVertex2._1.count() == 1)
+
+    assert(intervalWithEdge._2.count() == 1)
+    assert(intervalWithV1andEdge._1.count() == 1, intervalWithV1andEdge._2.count() == 1)
+    assert(intervalWithV2andEdge._1.count() == 1, intervalWithV2andEdge._2.count() == 1)
+
+    assert(intervalWithAll._1.count() == 2 && intervalWithV1andEdge._2.count() == 1)
   }
 }


### PR DESCRIPTION
Legger til activated entities på Landy. Refaktorerer også Payload til å være én klasse, siden den er lik for både vertices og edges. Bygger på #22 og må merges etter den