### PR TITLE
refactor: split activated entities

### DIFF
--- a/data-generation/src/main/scala/thesis/Landy.scala
+++ b/data-generation/src/main/scala/thesis/Landy.scala
@@ -31,12 +31,10 @@ class Landy(graph: LandyAttributeGraph) extends TemporalGraph[LandyVertexPayload
     Graph(vertices, edges)
   }
 
-  /** Return the ids of entities activated or created in the interval
-   *
-   * @param interval Inclusive interval
-   * @return Tuple with the activated entities
-   */
-  override def activatedEntities(interval: Interval): (RDD[VertexId], RDD[EdgeId]) = throw new NotImplementedError()
+  override def activatedVertices(interval: Interval): RDD[VertexId] = throw new NotImplementedError()
+
+  override def activatedEdges(interval: Interval): RDD[EdgeId] = throw new NotImplementedError()
+
 }
 
 object Landy {

--- a/data-generation/src/main/scala/thesis/SnapshotDelta.scala
+++ b/data-generation/src/main/scala/thesis/SnapshotDelta.scala
@@ -37,17 +37,18 @@ class SnapshotDelta(val graphs: MutableList[Snapshot],
         snap2
       })
 
-  /** Return the ids of entities activated or created in the interval
-   *
-   * @param interval Inclusive interval
-   * @return Tuple with the activated entities
-   */
-  override def activatedEntities(interval: Interval): (RDD[VertexId], RDD[EdgeId]) = {
+  override def activatedVertices(interval: Interval): RDD[VertexId] = {
     val relevantLogs = getLogsInInterval(logs, interval)
-    val (vertexSquash, edgeSquash) = getSquashedActionsByEntityId(relevantLogs)
-    val activatedVertices = vertexSquash.filter(_._2.action == CREATE).map(_._1)
-    val activatedEdges = edgeSquash.filter(_._2.action == CREATE).map(_._1)
-    (activatedVertices, activatedEdges)
+    val vertexSquash = getSquashedActionsByVertexId(relevantLogs)
+
+    vertexSquash.filter(_._2.action == CREATE).map(_._1)
+  }
+
+  override def activatedEdges(interval: Interval): RDD[EdgeId] = {
+    val relevantLogs = getLogsInInterval(logs, interval)
+    val edgeSquash = getSquashedActionsByEdgeId(relevantLogs)
+
+    edgeSquash.filter(_._2.action == CREATE).map(_._1)
   }
 
   override def snapshotAtTime(instant: Instant): AttributeGraph = {

--- a/data-generation/src/main/scala/thesis/TemporalGraph.scala
+++ b/data-generation/src/main/scala/thesis/TemporalGraph.scala
@@ -14,10 +14,31 @@ abstract class TemporalGraph[VD: ClassTag, ED: ClassTag] extends Serializable {
 
   def snapshotAtTime(instant: Instant): Graph[VD, ED]
 
-  /** Return the ids of entities activated or created in the interval
+  /** Return the ids of the entities that were either
+   * activated or created in the interval
    *
    * @param interval Inclusive interval
    * @return Tuple with the activated entities
    */
-  def activatedEntities(interval: Interval): (RDD[VertexId], RDD[EdgeId])
+  final def activatedEntities(interval: Interval): (RDD[VertexId], RDD[EdgeId]) = {
+    (activatedVertices(interval), activatedEdges(interval))
+  }
+
+  /**
+   * Return the ids of vertices that were either
+   * activated or created in the given interval
+   *
+   * @param interval Inclusive interval
+   * @return Tuple with the activated entities
+   */
+  def activatedVertices(interval: Interval): RDD[VertexId]
+
+  /**
+   * Return the ids of edges that were either
+   * activated or created in the given interval
+   *
+   * @param interval Inclusive interval
+   * @return Tuple with the activated entities
+   */
+  def activatedEdges(interval: Interval): RDD[EdgeId]
 }


### PR DESCRIPTION
Definerer `activatedEntities` på `TemporalGraph` samt å gjøre den final. Det kan være fint å splitte activated edges og activated vertices i og med at man ikke _trenger_ å gjøre begge to. Tenkte ikke på dette da jeg lagde #23 så må refaktorere der etter vi ev. merger denne.