### PR TITLE
fix: parse bug

### DIFF
--- a/data-generation/src/main/scala/thesis/LogTSV.scala
+++ b/data-generation/src/main/scala/thesis/LogTSV.scala
@@ -26,7 +26,7 @@ object LTSV {
    * @return String representation of the LogTSV
    */
   def serializeLTSV(logEntry: LogTSV): String = {
-    val timestamp = LocalDateTime.ofInstant(logEntry.timestamp, ZoneOffset.UTC).toString + "Z"
+    val timestamp = logEntry.timestamp.toString
     val action = logEntry.action match {
       case CREATE => "CREATE"
       case UPDATE => "UPDATE"


### PR DESCRIPTION
Bruker .toString for å serializere timestamps, slik at formatet ikke blir YYYY-mm-ddTHH:MM men YYYY-mm-ddTHH:MM:SS.
