### PR TITLE
refactor: interval utility functions

### DIFF
--- a/data-generation/src/main/scala/thesis/DataTypes.scala
+++ b/data-generation/src/main/scala/thesis/DataTypes.scala
@@ -5,6 +5,7 @@ import thesis.DataTypes.{AttributeGraph, Attributes, EdgeId}
 
 import java.time.Instant
 import scala.collection.immutable
+import scala.math.Ordered.orderingToOrdered
 
 object DataTypes {
   type AttributeGraph = Graph[Attributes, SnapshotEdgePayload]
@@ -13,7 +14,19 @@ object DataTypes {
   type EdgeId = Long
 }
 
-case class Interval(start: Instant, stop: Instant)
+case class Interval(start: Instant, stop: Instant) {
+  def overlaps(other: Interval): Boolean = {
+    this.contains(other.start) || other.contains(this.start)
+  }
+
+  def contains(other: Interval): Boolean = {
+    this.start <= other.start && other.stop <= this.stop
+  }
+
+  def contains(instant: Instant): Boolean = {
+    this.start <= instant && instant <= this.stop
+  }
+}
 
 case class SnapshotEdgePayload(id: EdgeId, attributes: Attributes)
 

--- a/data-generation/src/main/scala/thesis/Landy.scala
+++ b/data-generation/src/main/scala/thesis/Landy.scala
@@ -31,7 +31,7 @@ class Landy(graph: LandyAttributeGraph) extends TemporalGraph[LandyEntityPayload
     )
     Graph(vertices, edges)
   }
-  
+
   override def directNeighbours(vertexId: VertexId, interval: Interval): RDD[VertexId] = throw new NotImplementedError()
 
   override def activatedVertices(interval: Interval): RDD[VertexId] = {
@@ -40,7 +40,7 @@ class Landy(graph: LandyAttributeGraph) extends TemporalGraph[LandyEntityPayload
       .groupByKey() // Group all
       .map(vertex => (vertex._1, getEarliest(vertex._2.toSeq))) // Get first local vertex
 
-    firstLocalVertices.filter(vertex => isInstantInInterval(vertex._2.validFrom, interval))
+    firstLocalVertices.filter(vertex => interval.contains(vertex._2.validFrom))
       .map(vertex => vertex._2.id)
   }
 
@@ -49,7 +49,7 @@ class Landy(graph: LandyAttributeGraph) extends TemporalGraph[LandyEntityPayload
       .map(edge => (edge.attr.id, edge.attr))
       .groupByKey()
       .map(edge => (edge._1, getEarliest(edge._2.toSeq)))
-      .filter(edge => isInstantInInterval(edge._2.validFrom, interval))
+      .filter(edge => interval.contains(edge._2.validFrom))
       .map(edge => edge._1)
   }
 
@@ -70,10 +70,6 @@ class Landy(graph: LandyAttributeGraph) extends TemporalGraph[LandyEntityPayload
    */
   private def localVertices: VertexRDD[LandyEntityPayload] = {
     this.vertices.filter(vertex => vertex._2 != null)
-  }
-
-  private def isInstantInInterval(instant: Instant, interval: Interval): Boolean = {
-    instant >= interval.start && instant <= interval.stop
   }
 }
 

--- a/data-generation/src/test/scala/utils/IntervalSpec.scala
+++ b/data-generation/src/test/scala/utils/IntervalSpec.scala
@@ -1,0 +1,55 @@
+package utils
+
+import org.scalatest.flatspec.AnyFlatSpec
+import thesis.Interval
+
+import java.time.Instant
+
+class IntervalSpec extends AnyFlatSpec {
+
+  val t1: Instant = Instant.parse("2000-01-01T00:00:00Z")
+  val t2: Instant = Instant.parse("2000-01-01T01:00:00Z")
+  val t3: Instant = Instant.parse("2000-01-01T02:00:00Z")
+  val t4: Instant = Instant.parse("2000-01-01T03:00:00Z")
+  val t5: Instant = Instant.parse("2000-01-01T04:00:00Z")
+
+  "Intervals" can "overlap other intervals" in {
+    assert(Interval(t1, t3).overlaps(Interval(t2, t4)))
+    assert(Interval(t2, t4).overlaps(Interval(t1, t3)))
+  }
+
+  it can "overlap inclusively" in {
+    assert(Interval(t2, t3).overlaps(Interval(t1, t2)))
+    assert(Interval(t2, t3).overlaps(Interval(t3, t4)))
+  }
+
+  it should "not overlap non-overlapping intervals" in {
+    assert(!Interval(t1, t3).overlaps(Interval(t4, t5)))
+  }
+
+  it can "contain points" in {
+    assert(Interval(t1, t3).contains(t2))
+  }
+
+  it can "contain points in time inclusively" in {
+    assert(Interval(t1, t2).contains(t1))
+    assert(Interval(t1, t2).contains(t2))
+  }
+
+  it can "contain other intervals" in {
+    assert(Interval(t1, t4).contains(Interval(t2, t3)))
+  }
+
+  it can "contain itself" in {
+    val interval = Interval(t1, t2)
+    assert(interval.contains(interval))
+  }
+
+  it should "not contain overlapping intervals" in {
+    assert(!Interval(t1, t3).contains(Interval(t2, t4)))
+  }
+
+  it should "not contain non-overlapping intervals" in {
+    assert(!Interval(t1, t2).contains(Interval(t3, t4)))
+  }
+}


### PR DESCRIPTION
Endrer på `Interval` case classen med litt logikk for overlappende og inneholdende stuff