### PR TITLE
fix: benchmark file placement

### DIFF
--- a/data-generation/src/main/scala/Main.scala
+++ b/data-generation/src/main/scala/Main.scala
@@ -1,6 +1,23 @@
-import thesis.PossibleWorkFlow
+import factories.LogFactory
+import org.apache.spark.SparkContext
+import org.apache.spark.sql.SparkSession
+import thesis.SparkConfiguration.getSparkSession
+import thesis.{Landy, VERTEX}
+import utils.{Benchmark, FileWriter}
 
 
 object Main extends App {
-  PossibleWorkFlow.run()
+  val spark: SparkSession = getSparkSession
+  implicit val sc: SparkContext = spark.sparkContext
+
+  val b = Benchmark(FileWriter(filename = "snapshot-landy"), textPrefix = "Snapshot", customColumn = "number of logs")
+  b.writeHeader
+  for (i <- 1 to 5) {
+    val numberOfLogs = scala.math.pow(2, i.toDouble).toInt
+    val logs = LogFactory().buildSingleSequenceWithDelete(VERTEX(1), updateAmount = numberOfLogs)
+    val graph = Landy(sc.parallelize(logs))
+    val timestamp = logs.head.timestamp
+    b.benchmarkSingle(graph.snapshotAtTime(timestamp), customColumnValue = numberOfLogs.toString)
+  }
+  b.close() // should be called if its a FileWriter
 }

--- a/data-generation/src/main/scala/Main.scala
+++ b/data-generation/src/main/scala/Main.scala
@@ -1,23 +1,5 @@
-import factories.LogFactory
-import org.apache.spark.SparkContext
-import org.apache.spark.sql.SparkSession
-import thesis.SparkConfiguration.getSparkSession
-import thesis.{Landy, VERTEX}
-import utils.{Benchmark, FileWriter}
-
+import thesis.PossibleWorkFlow
 
 object Main extends App {
-  val spark: SparkSession = getSparkSession
-  implicit val sc: SparkContext = spark.sparkContext
-
-  val b = Benchmark(FileWriter(filename = "snapshot-landy"), textPrefix = "Snapshot", customColumn = "number of logs")
-  b.writeHeader
-  for (i <- 1 to 5) {
-    val numberOfLogs = scala.math.pow(2, i.toDouble).toInt
-    val logs = LogFactory().buildSingleSequenceWithDelete(VERTEX(1), updateAmount = numberOfLogs)
-    val graph = Landy(sc.parallelize(logs))
-    val timestamp = logs.head.timestamp
-    b.benchmarkSingle(graph.snapshotAtTime(timestamp), customColumnValue = numberOfLogs.toString)
-  }
-  b.close() // should be called if its a FileWriter
+  PossibleWorkFlow.run()
 }

--- a/data-generation/src/main/scala/utils/Benchmark.scala
+++ b/data-generation/src/main/scala/utils/Benchmark.scala
@@ -77,13 +77,30 @@ case class ConsoleWriter() extends Writer {
 }
 
 case class FileWriter(filename: String) extends Writer {
-  val pw = new java.io.PrintWriter(Instant.now().toString + "-" + filename + ".csv") // Unique name everytime, will never append to previous run
+  val pw = new java.io.PrintWriter(getFilePath(filename))
 
   override def write(str: String): Unit = {
     pw.append(str + "\n")
   }
 
   override def close(): Unit = pw.close()
+
+  /**
+   * Get the absolute file path to the benchmark output.
+   * Requires the user to have set the benchmark directory outside the root folder
+   * of the the project (master-thesis).
+   *
+   * @return A unique, absolute filepath
+   */
+  private def getFilePath(filename: String): String = {
+    val projectLocation = new java.io.File("../../").getCanonicalPath
+    val benchmarkDirectory = "/benchmarks/"
+    val timePrefix = Instant.now()
+      .toString
+      .split("\\.")(0) // Get the format YYYY-mm-ddTHH:MM:SS
+      .replace(":", "-")
+    s"$projectLocation$benchmarkDirectory$timePrefix-$filename.csv"
+  }
 }
 
 case class BothWriter(filename: String) extends Writer {


### PR DESCRIPTION
Med disse endringene forventes det nå at du har en /benchmarks/ i mappen rett utenfor prosjektet. Hvis prosjektet ditt er i `C:/me/master-thesis/` så forventes det da at du har en `C:/me/benchmarks/`.

Har også lagt til en commit du kan bruke for å teste, bare å kjøre:
`git reset --hard HEAD~1`. 
Eller cherry-picke commiten, men vet ikke hvordan det blir når du allerede har den commiten i historikken haha

Windows liker ikke kolon i file path, så måtte erstatte `:` -> `-`