### PR TITLE
Create companion object with fitting apply function for SnapshotDelta

### DIFF
--- a/data-generation/src/main/scala/thesis/PossibleWorkFlow.scala
+++ b/data-generation/src/main/scala/thesis/PossibleWorkFlow.scala
@@ -44,7 +44,7 @@ object PossibleWorkFlow {
       logs
     }
     logger.warn("Generate temporal model")
-    val snapshotModel = SnapshotDeltaObject.create(logs, SnapshotIntervalType.Count(10000))
+    val snapshotModel = SnapshotDelta.apply(logs, SnapshotIntervalType.Count(10000))
 
     println(s"Number of vertices in the first snapshot ${snapshotModel.graphs.head.graph.vertices.count()}")
     println(s"Number of logs ${logs.count()}")

--- a/data-generation/src/main/scala/thesis/SnapshotDelta.scala
+++ b/data-generation/src/main/scala/thesis/SnapshotDelta.scala
@@ -6,7 +6,7 @@ import org.apache.spark.rdd.RDD.rddToOrderedRDDFunctions
 import org.slf4j.{Logger, LoggerFactory}
 import thesis.Action.{CREATE, DELETE, UPDATE}
 import thesis.DataTypes.{AttributeGraph, Attributes, EdgeId}
-import thesis.SnapshotDeltaObject._
+import thesis.SnapshotDelta._
 import utils.{EntityFilterException, LogUtils}
 
 import java.time.{Duration, Instant}
@@ -177,10 +177,10 @@ class SnapshotDelta(val graphs: mutable.MutableList[Snapshot],
 }
 
 
-object SnapshotDeltaObject {
+object SnapshotDelta {
   def getLogger: Logger = LoggerFactory.getLogger("SnapShotDelta")
 
-  def create[VD, ED](logs: RDD[LogTSV], snapType: SnapshotIntervalType): SnapshotDelta = {
+  def apply[VD, ED](logs: RDD[LogTSV], snapType: SnapshotIntervalType): SnapshotDelta = {
     snapType match {
       // TODO the first argument logsWithSortableKey should be moved into the function
       case SnapshotIntervalType.Time(duration) => createSnapshotModel(logs.map(log => (log.timestamp.getEpochSecond, log)), snapType)

--- a/data-generation/src/main/scala/utils/LogUtils.scala
+++ b/data-generation/src/main/scala/utils/LogUtils.scala
@@ -1,5 +1,6 @@
 package utils
 
+import org.apache.spark.SparkContext
 import org.apache.spark.graphx.VertexId
 import org.apache.spark.rdd.RDD
 import thesis.{EDGE, Entity, LogTSV, VERTEX}
@@ -52,5 +53,9 @@ object LogUtils {
 
   def reverse(logs: Seq[LogTSV]): Seq[LogTSV] = {
     logs.sortWith((log1, log2) => log1.timestamp.isAfter(log2.timestamp))
+  }
+
+  implicit def seqToRdd(s: Seq[LogTSV])(implicit sc: SparkContext): RDD[LogTSV] = {
+    sc.parallelize(s)
   }
 }


### PR DESCRIPTION
Also move SeqToRdd to a more fitting place

This lets us do SnapshotDelta(logs, Time(4), instead of SnapshotDeltaObject.create(logs,Time(4). More idiomatic