### PR TITLE
feat: landy snapshot benchmark

### DIFF
--- a/data-generation/src/main/scala/benchmarks/QueryBenchmark.scala
+++ b/data-generation/src/main/scala/benchmarks/QueryBenchmark.scala
@@ -9,23 +9,28 @@ abstract class QueryBenchmark(val iterationCount: Int, val customColumn: String,
   var benchmarks: Seq[Benchmark] = Seq()
 
   def run: Unit = {
-    benchmarkSuffixes.length match {
-      case 0 => initialize()
-      case 1 => initialize()
-      case _ => initialize(benchmarkSuffixes)
-    }
+    initialize
     for (i <- 1 to iterationCount) {
       execute(i)
     }
     tearDown()
   }
 
-  def initialize(): Unit = {
+  private def initialize: Unit = {
+    benchmarkSuffixes.length match {
+      case 0 => initializeSingle()
+      case 1 => initializeSingle()
+      case _ => initializeMultiple(benchmarkSuffixes)
+    }
+    benchmarks.foreach(_.writeHeader())
+  }
+
+  def initializeSingle(): Unit = {
     val fileWriter = FileWriter(filename = getClass.getSimpleName)
     benchmarks = benchmarks :+ Benchmark(fileWriter, textPrefix = getClass.getSimpleName, customColumn = customColumn)
   }
 
-  def initialize(benchmarkSuffixes: Seq[String]): Unit = {
+  def initializeMultiple(benchmarkSuffixes: Seq[String]): Unit = {
     benchmarkSuffixes.foreach(suffix => {
       val benchmarkId = s"${getClass.getSimpleName}-$suffix"
       val fileWriter = FileWriter(filename = benchmarkId)

--- a/data-generation/src/main/scala/benchmarks/QueryBenchmark.scala
+++ b/data-generation/src/main/scala/benchmarks/QueryBenchmark.scala
@@ -1,0 +1,27 @@
+package benchmarks
+
+import org.apache.spark.SparkContext
+import thesis.SparkConfiguration.getSparkSession
+import utils.{Benchmark, FileWriter}
+
+abstract class QueryBenchmark(val iterationCount: Int, val customColumn: String) extends Serializable {
+  implicit val sc: SparkContext = getSparkSession.sparkContext
+  var benchmark: Benchmark = null
+
+  def run: Unit = {
+    initialize()
+    for (i <- 1 to iterationCount) {
+      execute(i)
+    }
+    tearDown()
+  }
+
+  def initialize(): Unit = {
+    val fileWriter = FileWriter(filename = getClass.getSimpleName)
+    benchmark = Benchmark(fileWriter, textPrefix = getClass.getSimpleName, customColumn = customColumn)
+  }
+
+  def execute(iteration: Int): Unit
+
+  def tearDown(): Unit = benchmark.close()
+}

--- a/data-generation/src/main/scala/benchmarks/QueryBenchmark.scala
+++ b/data-generation/src/main/scala/benchmarks/QueryBenchmark.scala
@@ -22,7 +22,7 @@ abstract class QueryBenchmark(val iterationCount: Int, val customColumn: String,
 
   def initialize(): Unit = {
     val fileWriter = FileWriter(filename = getClass.getSimpleName)
-    benchmarks :+ Benchmark(fileWriter, textPrefix = getClass.getSimpleName, customColumn = customColumn)
+    benchmarks = benchmarks :+ Benchmark(fileWriter, textPrefix = getClass.getSimpleName, customColumn = customColumn)
   }
 
   def initialize(benchmarkSuffixes: Seq[String]): Unit = {

--- a/data-generation/src/main/scala/benchmarks/SnapshotBenchmark.scala
+++ b/data-generation/src/main/scala/benchmarks/SnapshotBenchmark.scala
@@ -1,0 +1,15 @@
+package benchmarks
+
+import factories.LogFactory
+import thesis.{Landy, VERTEX}
+
+/** Benchmark landy snapshot with a variation of log numbers. */
+class SnapshotLandyBenchmark(iterationCount: Int = 5, customColumn: String = "number of logs") extends QueryBenchmark(iterationCount, customColumn) {
+  override def execute(iteration: Int): Unit = {
+    val numberOfLogs = iteration * 1000
+    val logs = LogFactory().buildSingleSequenceWithDelete(VERTEX(1), updateAmount = numberOfLogs)
+    val graph = Landy(sc.parallelize(logs))
+    val timestamp = logs.head.timestamp
+    benchmark.benchmarkAvg(graph.snapshotAtTime(timestamp), numberOfRuns = 5, customColumnValue = numberOfLogs.toString)
+  }
+}

--- a/data-generation/src/main/scala/benchmarks/SnapshotBenchmark.scala
+++ b/data-generation/src/main/scala/benchmarks/SnapshotBenchmark.scala
@@ -1,15 +1,25 @@
 package benchmarks
 
 import factories.LogFactory
-import thesis.{Landy, VERTEX}
+import thesis.SnapshotIntervalType.Count
+import thesis.{Landy, SnapshotDelta, VERTEX}
+import utils.{Benchmark, FileWriter}
 
 /** Benchmark landy snapshot with a variation of log numbers. */
-class SnapshotLandyBenchmark(iterationCount: Int = 5, customColumn: String = "number of logs") extends QueryBenchmark(iterationCount, customColumn) {
+class SnapshotLandyBenchmark(
+                              iterationCount: Int = 5,
+                              customColumn: String = "number of logs",
+                              benchmarkSuffixes: Seq[String] = Seq("landy", "snapshot")
+                            ) extends QueryBenchmark(iterationCount, customColumn, benchmarkSuffixes) {
+
   override def execute(iteration: Int): Unit = {
     val numberOfLogs = iteration * 1000
     val logs = LogFactory().buildSingleSequenceWithDelete(VERTEX(1), updateAmount = numberOfLogs)
-    val graph = Landy(sc.parallelize(logs))
+    val landyGraph = Landy(sc.parallelize(logs))
+    val snapshotGraph = SnapshotDelta(sc.parallelize(logs), Count(100))
     val timestamp = logs.head.timestamp
-    benchmark.benchmarkAvg(graph.snapshotAtTime(timestamp), numberOfRuns = 5, customColumnValue = numberOfLogs.toString)
+    benchmarks(0).benchmarkAvg(landyGraph.snapshotAtTime(timestamp), numberOfRuns = 5, customColumnValue = numberOfLogs.toString)
+    benchmarks(1).benchmarkAvg(snapshotGraph.snapshotAtTime(timestamp), numberOfRuns = 5, customColumnValue = numberOfLogs.toString)
+
   }
 }


### PR DESCRIPTION
Legger til litt struktur rundt kjøring av queries for å redusere koden som trengs å skrives. Trenger bare sette noen verdier når man lager QueryBenchmark-objektet og definere en `execute`-metode, som definerer hva som skal skje. Detaljer rundt `Benchmark`-opprettelse, FileWriter-opprettelse osv. tas hånd om av `QueryBenchmark`-instansen.