### PR TITLE
Quickfix for returning distinct ids in directNeighbours

### DIFF
--- a/data-generation/src/main/scala/thesis/Landy.scala
+++ b/data-generation/src/main/scala/thesis/Landy.scala
@@ -54,7 +54,7 @@ class Landy(underlyingGraph: LandyAttributeGraph) extends TemporalGraph {
     }
     )
       .map(edge => if (edge.dstId == vertexId) edge.srcId else edge.dstId)
-      .distinct // Quickfix, there were duplicates returned
+      .distinct
   }
 
   override def activatedVertices(interval: Interval): RDD[VertexId] = {

--- a/data-generation/src/main/scala/thesis/Landy.scala
+++ b/data-generation/src/main/scala/thesis/Landy.scala
@@ -54,6 +54,7 @@ class Landy(underlyingGraph: LandyAttributeGraph) extends TemporalGraph {
     }
     )
       .map(edge => if (edge.dstId == vertexId) edge.srcId else edge.dstId)
+      .distinct // Quickfix, there were duplicates returned
   }
 
   override def activatedVertices(interval: Interval): RDD[VertexId] = {

--- a/data-generation/src/main/scala/thesis/SnapshotDelta.scala
+++ b/data-generation/src/main/scala/thesis/SnapshotDelta.scala
@@ -103,7 +103,7 @@ class SnapshotDelta(val graphs: mutable.MutableList[Snapshot],
       })
       .filter(idWithInterval => interval.overlaps(idWithInterval._2))
       .map(_._1)
-      .distinct // Quickfix, there were duplicates returned
+      .distinct
   }
 
   /** Get entity at a certain point in time

--- a/data-generation/src/main/scala/thesis/SnapshotDelta.scala
+++ b/data-generation/src/main/scala/thesis/SnapshotDelta.scala
@@ -103,6 +103,7 @@ class SnapshotDelta(val graphs: mutable.MutableList[Snapshot],
       })
       .filter(idWithInterval => interval.overlaps(idWithInterval._2))
       .map(_._1)
+      .distinct // Quickfix, there were duplicates returned
   }
 
   /** Get entity at a certain point in time

--- a/data-generation/src/test/scala/SnapshotDeltaSpec.scala
+++ b/data-generation/src/test/scala/SnapshotDeltaSpec.scala
@@ -216,8 +216,8 @@ class SnapshotDeltaSpec extends AnyFlatSpec with SparkTestWrapper {
 
     // Assertions for 1L's neighbours through time
     assert(g.directNeighbours(1L, Interval(t1, t1)).collect().toSeq == Seq(2L))
-    assert(g.directNeighbours(1L, Interval(t2, t2)).collect().toSeq == Seq(2L, 3L))
-    assert(g.directNeighbours(1L, Interval(t2, t3)).collect().toSeq == Seq(2L, 3L))
+    assert(g.directNeighbours(1L, Interval(t2, t2)).collect().toSeq.sorted == Seq(2L, 3L))
+    assert(g.directNeighbours(1L, Interval(t2, t3)).collect().toSeq.sorted == Seq(2L, 3L))
     assert(g.directNeighbours(1L, Interval(t4, t4)).collect().toSeq == Seq(3L))
 
     // Assertions for 2L's neighbours through time

--- a/data-generation/src/test/scala/SnapshotLandySpec.scala
+++ b/data-generation/src/test/scala/SnapshotLandySpec.scala
@@ -92,8 +92,6 @@ class SnapshotLandySpec extends FixtureAnyFlatSpec with SparkTestWrapper {
     vertices.foreach(v => {
       val lVertexIds = landyGraph.directNeighbours(v.id, bothBatches).collect().sorted
       val sdVertexIds = snapshotDeltaGraph.directNeighbours(v.id, bothBatches).collect().sorted
-      println(lVertexIds.mkString("Array(", ", ", ")"))
-      println(sdVertexIds.mkString("Array(", ", ", ")"))
       lVertexIds.zip(sdVertexIds).foreach({ case (vId, uId) => assert(vId == uId) })
     }
     )


### PR DESCRIPTION
The tests was showing that both directNeighbours implementation  for landy and Sdelta returned duplicates. (They did return duplicates on different times which I found odd). Added a quickfix, but maybe a smarter/more effective solution can be done)