### PR TITLE
Implement some of spark.Graph methods

### DIFF
--- a/data-generation/src/main/scala/thesis/Landy.scala
+++ b/data-generation/src/main/scala/thesis/Landy.scala
@@ -1,7 +1,7 @@
 package thesis
 
 import org.apache.spark.SparkContext
-import org.apache.spark.graphx.{Edge, EdgeRDD, Graph, VertexId, VertexRDD}
+import org.apache.spark.graphx.{Edge, Graph, VertexId, VertexRDD}
 import org.apache.spark.rdd.RDD
 import thesis.Action.{CREATE, UPDATE}
 import thesis.DataTypes.{Attributes, EdgeId, LandyAttributeGraph}
@@ -13,8 +13,6 @@ import scala.math.Ordered.orderingToOrdered
 
 
 class Landy(underlyingGraph: LandyAttributeGraph) extends TemporalGraph {
-  val vertices: VertexRDD[LandyEntityPayload] = underlyingGraph.vertices
-  val edges: EdgeRDD[LandyEntityPayload] = underlyingGraph.edges
 
   def snapshotAtTimeLandy(instant: Instant): Graph[LandyEntityPayload, LandyEntityPayload] = {
     val vertices = localVertices

--- a/data-generation/src/main/scala/thesis/Landy.scala
+++ b/data-generation/src/main/scala/thesis/Landy.scala
@@ -12,7 +12,8 @@ import scala.collection.mutable
 import scala.math.Ordered.orderingToOrdered
 
 
-class Landy(underlyingGraph: LandyAttributeGraph) extends TemporalGraph {
+class Landy(attributeGraph: LandyAttributeGraph) extends TemporalGraph {
+  val underlyingGraph: LandyAttributeGraph = attributeGraph
 
   def snapshotAtTimeLandy(instant: Instant): Graph[LandyEntityPayload, LandyEntityPayload] = {
     val vertices = localVertices

--- a/data-generation/src/main/scala/thesis/TemporalGraph.scala
+++ b/data-generation/src/main/scala/thesis/TemporalGraph.scala
@@ -1,17 +1,44 @@
 package thesis
 
-import org.apache.spark.graphx.VertexId
+import org.apache.spark.graphx.{Edge, EdgeContext, EdgeRDD, EdgeTriplet, Graph, GraphOps, TripletFields, VertexId, VertexRDD}
 import org.apache.spark.rdd.RDD
-import thesis.DataTypes.{Attributes, EdgeId}
+import thesis.DataTypes.{AttributeGraph, Attributes, EdgeId}
 
 import java.time.Instant
+import scala.reflect.ClassTag
 
 abstract class TemporalGraph extends Serializable {
-  //  val vertices: VertexRDD[Attributes]
-  //  val edges: EdgeRDD[SnapshotEdgePayload]
-  //  val triplets: RDD[EdgeTriplet[Attributes, SnapshotEdgePayload]]
+  val vertices: VertexRDD[Attributes] = snapshotAtTime(Instant.now()).graph.vertices
+  val edges: EdgeRDD[SnapshotEdgePayload] = snapshotAtTime(Instant.now()).graph.edges
+  val triplets: RDD[EdgeTriplet[Attributes, SnapshotEdgePayload]] = snapshotAtTime(Instant.now()).graph.triplets
+
+  val ops: GraphOps[Attributes, SnapshotEdgePayload] = graph.ops
+  val graph: AttributeGraph = snapshotAtTime(Instant.now()).graph
+
+
+  def mapVertices[T: ClassTag](map: (VertexId, Attributes) => T): Graph[T, SnapshotEdgePayload] =
+    graph.mapVertices(map)
+
+  def mapEdges[T: ClassTag](map: Edge[SnapshotEdgePayload] => T): Graph[Attributes, T] =
+    graph.mapEdges(map)
+
+  def reverse: Graph[Attributes, SnapshotEdgePayload] = graph.reverse
+
 
   def snapshotAtTime(instant: Instant): Snapshot
+
+  def subgraph(
+                epred: EdgeTriplet[Attributes, SnapshotEdgePayload] => Boolean = (x => true),
+                vpred: (VertexId, Attributes) => Boolean = ((v, d) => true))
+  : Graph[Attributes, SnapshotEdgePayload]
+  = graph.subgraph(epred, vpred)
+
+  def aggregateMessages[A: ClassTag](
+                                      sendMsg: EdgeContext[Attributes, SnapshotEdgePayload, A] => Unit,
+                                      mergeMsg: (A, A) => A,
+                                      tripletFields: TripletFields = TripletFields.All)
+  : VertexRDD[A] =
+    graph.aggregateMessages(sendMsg, mergeMsg, tripletFields)
 
 
   /**

--- a/data-generation/src/main/scala/thesis/TemporalGraph.scala
+++ b/data-generation/src/main/scala/thesis/TemporalGraph.scala
@@ -8,21 +8,23 @@ import java.time.Instant
 import scala.reflect.ClassTag
 
 abstract class TemporalGraph extends Serializable {
-  val vertices: () => VertexRDD[Attributes] = () => snapshotAtTime(Instant.now()).graph.vertices
-  val edges: () => EdgeRDD[SnapshotEdgePayload] = () => snapshotAtTime(Instant.now()).graph.edges
-  val triplets: () => RDD[EdgeTriplet[Attributes, SnapshotEdgePayload]] = () => snapshotAtTime(Instant.now()).graph.triplets
+  lazy val vertices: VertexRDD[Attributes] = graph.vertices
+  lazy val edges: EdgeRDD[SnapshotEdgePayload] = graph.edges
+  lazy val triplets: RDD[EdgeTriplet[Attributes, SnapshotEdgePayload]] = graph.triplets
 
-  val graph: () => AttributeGraph = () => snapshotAtTime(Instant.now()).graph
-  val ops: GraphOps[Attributes, SnapshotEdgePayload] = graph().ops
+  lazy val graph: AttributeGraph = snapshotAtTime(Instant.now()).graph
+  lazy val ops: GraphOps[Attributes, SnapshotEdgePayload] = graph.ops
+
+  def getCurrentGraph: AttributeGraph = snapshotAtTime(Instant.now()).graph
 
 
   def mapVertices[T: ClassTag](map: (VertexId, Attributes) => T): Graph[T, SnapshotEdgePayload] =
-    graph().mapVertices(map)
+    graph.mapVertices(map)
 
   def mapEdges[T: ClassTag](map: Edge[SnapshotEdgePayload] => T): Graph[Attributes, T] =
-    graph().mapEdges(map)
+    graph.mapEdges(map)
 
-  def reverse: Graph[Attributes, SnapshotEdgePayload] = graph().reverse
+  def reverse: Graph[Attributes, SnapshotEdgePayload] = graph.reverse
 
 
   def snapshotAtTime(instant: Instant): Snapshot
@@ -31,14 +33,14 @@ abstract class TemporalGraph extends Serializable {
                 epred: EdgeTriplet[Attributes, SnapshotEdgePayload] => Boolean = (x => true),
                 vpred: (VertexId, Attributes) => Boolean = ((v, d) => true))
   : Graph[Attributes, SnapshotEdgePayload]
-  = graph().subgraph(epred, vpred)
+  = graph.subgraph(epred, vpred)
 
   def aggregateMessages[A: ClassTag](
                                       sendMsg: EdgeContext[Attributes, SnapshotEdgePayload, A] => Unit,
                                       mergeMsg: (A, A) => A,
                                       tripletFields: TripletFields = TripletFields.All)
   : VertexRDD[A] =
-    graph().aggregateMessages(sendMsg, mergeMsg, tripletFields)
+    graph.aggregateMessages(sendMsg, mergeMsg, tripletFields)
 
 
   /**

--- a/data-generation/src/test/scala/LandyConsumerSpec.scala
+++ b/data-generation/src/test/scala/LandyConsumerSpec.scala
@@ -9,20 +9,20 @@ class LandyConsumerSpec extends AnyFlatSpec with SparkTestWrapper {
     implicit val sc: SparkContext = spark.sparkContext
     val logs = LogFactory().buildSingleSequence(VERTEX(10))
     val logsRDD = sc.parallelize(logs)
-    val graph = Landy(logsRDD)
+    val landy = Landy(logsRDD)
 
-    assert(graph.vertices.count() == 5)
-    assert(graph.edges.count() == 0)
+    assert(landy.underlyingGraph.vertices.count() == 5)
+    assert(landy.underlyingGraph.edges.count() == 0)
   }
 
   it can "consume edges" in {
     implicit val sc: SparkContext = spark.sparkContext
     val logs = LogFactory().buildSingleSequence(EDGE(1, 10, 11))
     val logsRDD = sc.parallelize(logs)
-    val graph = Landy(logsRDD)
+    val landy = Landy(logsRDD)
 
-    assert(graph.vertices.count() == 2)
-    assert(graph.edges.count() == 5)
+    assert(landy.underlyingGraph.vertices.count() == 2)
+    assert(landy.underlyingGraph.edges.count() == 5)
 
 
   }

--- a/data-generation/src/test/scala/LandySpec.scala
+++ b/data-generation/src/test/scala/LandySpec.scala
@@ -15,8 +15,8 @@ class LandySpec extends AnyFlatSpec with SparkTestWrapper {
   "Landy" can "be created" in {
     val landy: Landy = new Landy(createGraph())
 
-    assert(landy.vertices().count() == 5)
-    assert(landy.edges().count() == 2)
+    assert(landy.underlyingGraph.vertices.count() == 5)
+    assert(landy.underlyingGraph.edges.count() == 2)
   }
 
   it can "give a snapshot" in {

--- a/data-generation/src/test/scala/LandySpec.scala
+++ b/data-generation/src/test/scala/LandySpec.scala
@@ -15,8 +15,8 @@ class LandySpec extends AnyFlatSpec with SparkTestWrapper {
   "Landy" can "be created" in {
     val landy: Landy = new Landy(createGraph())
 
-    assert(landy.vertices.count() == 5)
-    assert(landy.edges.count() == 2)
+    assert(landy.vertices().count() == 5)
+    assert(landy.edges().count() == 2)
   }
 
   it can "give a snapshot" in {


### PR DESCRIPTION
Jeg ville egentlig extende spark.Graph men flere av metodene gir ikke mening for temporal graph. `.persist` og `.cache` f.eks. som har side effects. Så jeg implementere noen av metodene, men hvis man vil ha alle så kan man jo bare `Temporalgraph.graph`. 

Eksempel som viser hvor teit denne PRen er
```scala
val myVertices = temporalgraph.vertices //Grafen må materialiserer
val myEdges = temporalgraph.edges // Grafen må materialiseres på nytt!

vs

val myGraph = temporalgraph.graph // Grafen materialiseres 1 gang
val myVertices = myGraph.vertices
val myEdges = myGraph.edges
```
Eksempelet gir muligens feil konklusjon hvis vi har vært flinke nok med lazynessen vår. 